### PR TITLE
refactor(cli): improve code style and module architecture

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -50,19 +50,19 @@ pub enum Commands {
 
     /// Test tool
     Test {
-        /// Tool to test [lookup_crate, search_crates, lookup_item, health_check]
+        /// Tool to test [`lookup_crate`], [`search_crates`], [`lookup_item`], [`health_check`]
         #[arg(short, long, default_value = "lookup_crate")]
         tool: String,
 
-        /// Crate name (for lookup_crate and lookup_item)
+        /// Crate name (for [`lookup_crate`] and [`lookup_item`])
         #[arg(long)]
         crate_name: Option<String>,
 
-        /// Item path (for lookup_item)
+        /// Item path (for [`lookup_item`])
         #[arg(long)]
         item_path: Option<String>,
 
-        /// Search query (for search_crates)
+        /// Search query (for [`search_crates`])
         #[arg(long)]
         query: Option<String>,
 
@@ -70,18 +70,18 @@ pub enum Commands {
         #[arg(long)]
         version: Option<String>,
 
-        /// Result limit (for search_crates)
+        /// Result limit (for [`search_crates`])
         #[arg(long, default_value = "10")]
         limit: u32,
 
-        /// Output format [json, markdown, text]
+        /// Output format [`json`], [`markdown`], [`text`]
         #[arg(long, default_value = "markdown")]
         format: String,
     },
 
     /// Check server health status
     Health {
-        /// Check type [all, external, internal, docs_rs, crates_io]
+        /// Check type [`all`], [`external`], [`internal`], [`docs_rs`], [`crates_io`]
         #[arg(short = 't', long, default_value = "all")]
         check_type: String,
 

--- a/src/cli/config_cmd.rs
+++ b/src/cli/config_cmd.rs
@@ -12,10 +12,10 @@ pub fn run_config_command(output: &PathBuf, force: bool) -> Result<(), Box<dyn s
         .into());
     }
 
-    let config = crates_docs::config::AppConfig::default();
+    let config = crate::config::AppConfig::default();
     config
         .save_to_file(output)
-        .map_err(|e| format!("Failed to save config file: {}", e))?;
+        .map_err(|e| format!("Failed to save config file: {e}"))?;
 
     println!("Config file generated: {}", output.display());
     println!("Please edit the config file as needed.");

--- a/src/cli/health_cmd.rs
+++ b/src/cli/health_cmd.rs
@@ -5,8 +5,8 @@ pub async fn run_health_command(
     check_type: &str,
     verbose: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    println!("Performing health check: {}", check_type);
-    println!("Verbose mode: {}", verbose);
+    println!("Performing health check: {check_type}");
+    println!("Verbose mode: {verbose}");
 
     // Actual health check logic can be added here
     println!("Health check completed (simulated)");

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -25,6 +25,7 @@ pub use version_cmd::run_version_command;
 #[command(version = env!("CARGO_PKG_VERSION"))]
 #[command(about = "High-performance Rust crate documentation query MCP server", long_about = None)]
 pub struct Cli {
+    /// CLI command to execute
     #[command(subcommand)]
     pub command: Commands,
 

--- a/src/cli/serve_cmd.rs
+++ b/src/cli/serve_cmd.rs
@@ -1,7 +1,7 @@
 //! Serve command implementation
 
-use crates_docs::server::transport;
-use crates_docs::CratesDocsServer;
+use crate::server::transport;
+use crate::CratesDocsServer;
 use std::path::PathBuf;
 
 /// Start server command
@@ -27,8 +27,7 @@ pub async fn run_serve_command(
         oauth_client_id,
         oauth_client_secret,
         oauth_redirect_uri,
-    )
-    .await?;
+    )?;
 
     // Get the actual transport mode (for logging and startup)
     let transport_mode = config.server.transport_mode.clone();
@@ -38,10 +37,10 @@ pub async fn run_serve_command(
         // In debug mode, override log level from config file
         let mut debug_config = config.logging.clone();
         debug_config.level = "debug".to_string();
-        crates_docs::init_logging_with_config(&debug_config)
+        crate::init_logging_with_config(&debug_config)
             .map_err(|e| format!("Failed to initialize logging system: {e}"))?;
     } else {
-        crates_docs::init_logging_with_config(&config.logging)
+        crate::init_logging_with_config(&config.logging)
             .map_err(|e| format!("Failed to initialize logging system: {e}"))?;
     }
 
@@ -53,7 +52,7 @@ pub async fn run_serve_command(
     // Create server (async to support Redis)
     let server: CratesDocsServer = CratesDocsServer::new_async(config)
         .await
-        .map_err(|e| format!("Failed to create server: {}", e))?;
+        .map_err(|e| format!("Failed to create server: {e}"))?;
 
     // Start server based on mode
     match transport_mode.to_lowercase().as_str() {
@@ -61,7 +60,7 @@ pub async fn run_serve_command(
             tracing::info!("Using Stdio transport mode");
             transport::run_stdio_server(&server)
                 .await
-                .map_err(|e| format!("Failed to start Stdio server: {}", e))?;
+                .map_err(|e| format!("Failed to start Stdio server: {e}"))?;
         }
         "http" => {
             tracing::info!(
@@ -71,7 +70,7 @@ pub async fn run_serve_command(
             );
             transport::run_http_server(&server)
                 .await
-                .map_err(|e| format!("Failed to start HTTP server: {}", e))?;
+                .map_err(|e| format!("Failed to start HTTP server: {e}"))?;
         }
         "sse" => {
             tracing::info!(
@@ -81,7 +80,7 @@ pub async fn run_serve_command(
             );
             transport::run_sse_server(&server)
                 .await
-                .map_err(|e| format!("Failed to start SSE server: {}", e))?;
+                .map_err(|e| format!("Failed to start SSE server: {e}"))?;
         }
         "hybrid" => {
             tracing::info!(
@@ -91,10 +90,10 @@ pub async fn run_serve_command(
             );
             transport::run_hybrid_server(&server)
                 .await
-                .map_err(|e| format!("Failed to start hybrid server: {}", e))?;
+                .map_err(|e| format!("Failed to start hybrid server: {e}"))?;
         }
         _ => {
-            return Err(format!("Unknown transport mode: {}", transport_mode).into());
+            return Err(format!("Unknown transport mode: {transport_mode}").into());
         }
     }
 
@@ -103,7 +102,7 @@ pub async fn run_serve_command(
 
 /// Load configuration
 #[allow(clippy::too_many_arguments)]
-async fn load_config(
+fn load_config(
     config_path: &PathBuf,
     host: Option<String>,
     port: Option<u16>,
@@ -112,17 +111,17 @@ async fn load_config(
     oauth_client_id: Option<String>,
     oauth_client_secret: Option<String>,
     oauth_redirect_uri: Option<String>,
-) -> Result<crates_docs::config::AppConfig, Box<dyn std::error::Error>> {
+) -> Result<crate::config::AppConfig, Box<dyn std::error::Error>> {
     let mut config = if config_path.exists() {
         tracing::info!("Loading configuration from file: {}", config_path.display());
-        crates_docs::config::AppConfig::from_file(config_path)
-            .map_err(|e| format!("Failed to load config file: {}", e))?
+        crate::config::AppConfig::from_file(config_path)
+            .map_err(|e| format!("Failed to load config file: {e}"))?
     } else {
         tracing::warn!(
             "Config file does not exist, using default config: {}",
             config_path.display()
         );
-        crates_docs::config::AppConfig::default()
+        crate::config::AppConfig::default()
     };
 
     // Only override config file when command line arguments are explicitly provided
@@ -170,7 +169,7 @@ async fn load_config(
     // Validate configuration
     config
         .validate()
-        .map_err(|e| format!("Configuration validation failed: {}", e))?;
+        .map_err(|e| format!("Configuration validation failed: {e}"))?;
 
     Ok(config)
 }

--- a/src/cli/test_cmd.rs
+++ b/src/cli/test_cmd.rs
@@ -17,7 +17,7 @@ pub async fn run_test_command(
     tracing::info!("Testing tool: {}", tool);
 
     // Create cache
-    let cache_config = crates_docs::cache::CacheConfig {
+    let cache_config = crate::cache::CacheConfig {
         cache_type: "memory".to_string(),
         memory_size: Some(1000),
         default_ttl: Some(3600),
@@ -25,14 +25,14 @@ pub async fn run_test_command(
         key_prefix: String::new(),
     };
 
-    let cache = crates_docs::cache::create_cache(&cache_config)?;
-    let cache_arc: Arc<dyn crates_docs::cache::Cache> = Arc::from(cache);
+    let cache = crate::cache::create_cache(&cache_config)?;
+    let cache_arc: Arc<dyn crate::cache::Cache> = Arc::from(cache);
 
     // Create document service
-    let doc_service = Arc::new(crates_docs::tools::docs::DocService::new(cache_arc));
+    let doc_service = Arc::new(crate::tools::docs::DocService::new(cache_arc));
 
     // Create tool registry
-    let registry = crates_docs::tools::create_default_registry(&doc_service);
+    let registry = crate::tools::create_default_registry(&doc_service);
 
     match tool {
         "lookup_crate" => {
@@ -48,7 +48,7 @@ pub async fn run_test_command(
             execute_health_check(&registry).await?;
         }
         _ => {
-            return Err(format!("Unknown tool: {}", tool).into());
+            return Err(format!("Unknown tool: {tool}").into());
         }
     }
 
@@ -56,16 +56,16 @@ pub async fn run_test_command(
     Ok(())
 }
 
-/// Execute lookup_crate tool
+/// Execute `lookup_crate` tool
 async fn execute_lookup_crate(
     crate_name: Option<&str>,
     version: Option<&str>,
     format: &str,
-    registry: &crates_docs::tools::ToolRegistry,
+    registry: &crate::tools::ToolRegistry,
 ) -> Result<(), Box<dyn std::error::Error>> {
     if let Some(name) = crate_name {
-        println!("Testing crate lookup: {} (version: {:?})", name, version);
-        println!("Output format: {}", format);
+        println!("Testing crate lookup: {name} (version: {version:?})");
+        println!("Output format: {format}");
 
         // Prepare arguments
         let mut arguments = serde_json::json!({
@@ -80,7 +80,7 @@ async fn execute_lookup_crate(
         // Execute tool
         match registry.execute_tool("lookup_crate", arguments).await {
             Ok(result) => print_tool_result(&result),
-            Err(e) => eprintln!("Tool execution failed: {}", e),
+            Err(e) => eprintln!("Tool execution failed: {e}"),
         }
     } else {
         return Err("lookup_crate requires --crate-name parameter".into());
@@ -88,16 +88,16 @@ async fn execute_lookup_crate(
     Ok(())
 }
 
-/// Execute search_crates tool
+/// Execute `search_crates` tool
 async fn execute_search_crates(
     query: Option<&str>,
     limit: u32,
     format: &str,
-    registry: &crates_docs::tools::ToolRegistry,
+    registry: &crate::tools::ToolRegistry,
 ) -> Result<(), Box<dyn std::error::Error>> {
     if let Some(q) = query {
-        println!("Testing crate search: {} (limit: {})", q, limit);
-        println!("Output format: {}", format);
+        println!("Testing crate search: {q} (limit: {limit})");
+        println!("Output format: {format}");
 
         // Prepare arguments
         let arguments = serde_json::json!({
@@ -109,7 +109,7 @@ async fn execute_search_crates(
         // Execute tool
         match registry.execute_tool("search_crates", arguments).await {
             Ok(result) => print_tool_result(&result),
-            Err(e) => eprintln!("Tool execution failed: {}", e),
+            Err(e) => eprintln!("Tool execution failed: {e}"),
         }
     } else {
         return Err("search_crates requires --query parameter".into());
@@ -117,20 +117,17 @@ async fn execute_search_crates(
     Ok(())
 }
 
-/// Execute lookup_item tool
+/// Execute `lookup_item` tool
 async fn execute_lookup_item(
     crate_name: Option<&str>,
     item_path: Option<&str>,
     version: Option<&str>,
     format: &str,
-    registry: &crates_docs::tools::ToolRegistry,
+    registry: &crate::tools::ToolRegistry,
 ) -> Result<(), Box<dyn std::error::Error>> {
     if let (Some(name), Some(path)) = (crate_name, item_path) {
-        println!(
-            "Testing item lookup: {}::{} (version: {:?})",
-            name, path, version
-        );
-        println!("Output format: {}", format);
+        println!("Testing item lookup: {name}::{path} (version: {version:?})");
+        println!("Output format: {format}");
 
         // Prepare arguments
         let mut arguments = serde_json::json!({
@@ -146,7 +143,7 @@ async fn execute_lookup_item(
         // Execute tool
         match registry.execute_tool("lookup_item", arguments).await {
             Ok(result) => print_tool_result(&result),
-            Err(e) => eprintln!("Tool execution failed: {}", e),
+            Err(e) => eprintln!("Tool execution failed: {e}"),
         }
     } else {
         return Err("lookup_item requires --crate-name and --item-path parameters".into());
@@ -154,9 +151,9 @@ async fn execute_lookup_item(
     Ok(())
 }
 
-/// Execute health_check tool
+/// Execute `health_check` tool
 async fn execute_health_check(
-    registry: &crates_docs::tools::ToolRegistry,
+    registry: &crate::tools::ToolRegistry,
 ) -> Result<(), Box<dyn std::error::Error>> {
     println!("Testing health check");
 
@@ -169,7 +166,7 @@ async fn execute_health_check(
     // Execute tool
     match registry.execute_tool("health_check", arguments).await {
         Ok(result) => print_tool_result(&result),
-        Err(e) => eprintln!("Tool execution failed: {}", e),
+        Err(e) => eprintln!("Tool execution failed: {e}"),
     }
     Ok(())
 }
@@ -183,7 +180,7 @@ fn print_tool_result(result: &rust_mcp_sdk::schema::CallToolResult) {
                 println!("{}", text_content.text);
             }
             other => {
-                println!("Non-text content: {:?}", other);
+                println!("Non-text content: {other:?}");
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 #![allow(clippy::missing_panics_doc)]
 
 pub mod cache;
+pub mod cli;
 pub mod config;
 pub mod error;
 pub mod server;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,7 @@
 //! Crates Docs MCP Server main program
 
-mod cli;
-
 use clap::Parser;
-use cli::{run, Cli};
+use crates_docs::cli::{run, Cli};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/tests/unit/cli_tests.rs
+++ b/tests/unit/cli_tests.rs
@@ -1,0 +1,624 @@
+//! CLI 模块单元测试
+
+use clap::Parser;
+use std::path::PathBuf;
+
+// ============================================================================
+// Cli 结构体测试
+// ============================================================================
+
+/// 测试 Cli 结构体解析 - Serve 命令
+#[test]
+fn test_cli_parse_serve_command() {
+    let cli = crates_docs::cli::Cli::try_parse_from([
+        "crates-docs",
+        "serve",
+        "--mode",
+        "http",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "9090",
+    ]);
+
+    assert!(cli.is_ok());
+    let cli = cli.unwrap();
+    match cli.command {
+        crates_docs::cli::Commands::Serve {
+            mode,
+            host,
+            port,
+            enable_oauth,
+            oauth_client_id,
+            oauth_client_secret,
+            oauth_redirect_uri,
+        } => {
+            assert_eq!(mode, Some("http".to_string()));
+            assert_eq!(host, Some("0.0.0.0".to_string()));
+            assert_eq!(port, Some(9090));
+            assert!(enable_oauth.is_none());
+            assert!(oauth_client_id.is_none());
+            assert!(oauth_client_secret.is_none());
+            assert!(oauth_redirect_uri.is_none());
+        }
+        _ => panic!("Expected Serve command"),
+    }
+}
+
+/// 测试 Cli 结构体解析 - Serve 命令带 OAuth 参数
+#[test]
+fn test_cli_parse_serve_command_with_oauth() {
+    let cli = crates_docs::cli::Cli::try_parse_from([
+        "crates-docs",
+        "serve",
+        "--enable-oauth",
+        "true",
+        "--oauth-client-id",
+        "test-client-id",
+        "--oauth-client-secret",
+        "test-secret",
+        "--oauth-redirect-uri",
+        "http://localhost:8080/callback",
+    ]);
+
+    assert!(cli.is_ok());
+    let cli = cli.unwrap();
+    match cli.command {
+        crates_docs::cli::Commands::Serve {
+            enable_oauth,
+            oauth_client_id,
+            oauth_client_secret,
+            oauth_redirect_uri,
+            ..
+        } => {
+            assert_eq!(enable_oauth, Some(true));
+            assert_eq!(oauth_client_id, Some("test-client-id".to_string()));
+            assert_eq!(oauth_client_secret, Some("test-secret".to_string()));
+            assert_eq!(
+                oauth_redirect_uri,
+                Some("http://localhost:8080/callback".to_string())
+            );
+        }
+        _ => panic!("Expected Serve command"),
+    }
+}
+
+/// 测试 Cli 结构体解析 - Config 命令
+#[test]
+fn test_cli_parse_config_command() {
+    let cli = crates_docs::cli::Cli::try_parse_from([
+        "crates-docs",
+        "config",
+        "--output",
+        "/tmp/test-config.toml",
+        "--force",
+    ]);
+
+    assert!(cli.is_ok());
+    let cli = cli.unwrap();
+    match cli.command {
+        crates_docs::cli::Commands::Config { output, force } => {
+            assert_eq!(output, PathBuf::from("/tmp/test-config.toml"));
+            assert!(force);
+        }
+        _ => panic!("Expected Config command"),
+    }
+}
+
+/// 测试 Cli 结构体解析 - Config 命令默认值
+#[test]
+fn test_cli_parse_config_command_defaults() {
+    let cli = crates_docs::cli::Cli::try_parse_from(["crates-docs", "config"]);
+
+    assert!(cli.is_ok());
+    let cli = cli.unwrap();
+    match cli.command {
+        crates_docs::cli::Commands::Config { output, force } => {
+            assert_eq!(output, PathBuf::from("config.toml"));
+            assert!(!force);
+        }
+        _ => panic!("Expected Config command"),
+    }
+}
+
+/// 测试 Cli 结构体解析 - Test 命令
+#[test]
+fn test_cli_parse_test_command() {
+    let cli = crates_docs::cli::Cli::try_parse_from([
+        "crates-docs",
+        "test",
+        "--tool",
+        "search_crates",
+        "--query",
+        "serde",
+        "--limit",
+        "20",
+        "--format",
+        "json",
+    ]);
+
+    assert!(cli.is_ok());
+    let cli = cli.unwrap();
+    match cli.command {
+        crates_docs::cli::Commands::Test {
+            tool,
+            crate_name,
+            item_path,
+            query,
+            version,
+            limit,
+            format,
+        } => {
+            assert_eq!(tool, "search_crates");
+            assert!(crate_name.is_none());
+            assert!(item_path.is_none());
+            assert_eq!(query, Some("serde".to_string()));
+            assert!(version.is_none());
+            assert_eq!(limit, 20);
+            assert_eq!(format, "json");
+        }
+        _ => panic!("Expected Test command"),
+    }
+}
+
+/// 测试 Cli 结构体解析 - Test 命令默认值
+#[test]
+fn test_cli_parse_test_command_defaults() {
+    let cli = crates_docs::cli::Cli::try_parse_from(["crates-docs", "test"]);
+
+    assert!(cli.is_ok());
+    let cli = cli.unwrap();
+    match cli.command {
+        crates_docs::cli::Commands::Test {
+            tool,
+            limit,
+            format,
+            ..
+        } => {
+            assert_eq!(tool, "lookup_crate");
+            assert_eq!(limit, 10);
+            assert_eq!(format, "markdown");
+        }
+        _ => panic!("Expected Test command"),
+    }
+}
+
+/// 测试 Cli 结构体解析 - Test 命令带所有参数
+#[test]
+fn test_cli_parse_test_command_all_args() {
+    let cli = crates_docs::cli::Cli::try_parse_from([
+        "crates-docs",
+        "test",
+        "--tool",
+        "lookup_item",
+        "--crate-name",
+        "serde",
+        "--item-path",
+        "Deserialize",
+        "--version",
+        "1.0.0",
+        "--limit",
+        "5",
+        "--format",
+        "text",
+    ]);
+
+    assert!(cli.is_ok());
+    let cli = cli.unwrap();
+    match cli.command {
+        crates_docs::cli::Commands::Test {
+            tool,
+            crate_name,
+            item_path,
+            query,
+            version,
+            limit,
+            format,
+        } => {
+            assert_eq!(tool, "lookup_item");
+            assert_eq!(crate_name, Some("serde".to_string()));
+            assert_eq!(item_path, Some("Deserialize".to_string()));
+            assert!(query.is_none());
+            assert_eq!(version, Some("1.0.0".to_string()));
+            assert_eq!(limit, 5);
+            assert_eq!(format, "text");
+        }
+        _ => panic!("Expected Test command"),
+    }
+}
+
+/// 测试 Cli 结构体解析 - Health 命令
+#[test]
+fn test_cli_parse_health_command() {
+    let cli = crates_docs::cli::Cli::try_parse_from([
+        "crates-docs",
+        "health",
+        "--check-type",
+        "external",
+        "--verbose",
+    ]);
+
+    assert!(cli.is_ok());
+    let cli = cli.unwrap();
+    match cli.command {
+        crates_docs::cli::Commands::Health {
+            check_type,
+            verbose,
+        } => {
+            assert_eq!(check_type, "external");
+            assert!(verbose);
+        }
+        _ => panic!("Expected Health command"),
+    }
+}
+
+/// 测试 Cli 结构体解析 - Health 命令默认值
+#[test]
+fn test_cli_parse_health_command_defaults() {
+    let cli = crates_docs::cli::Cli::try_parse_from(["crates-docs", "health"]);
+
+    assert!(cli.is_ok());
+    let cli = cli.unwrap();
+    match cli.command {
+        crates_docs::cli::Commands::Health {
+            check_type,
+            verbose,
+        } => {
+            assert_eq!(check_type, "all");
+            assert!(!verbose);
+        }
+        _ => panic!("Expected Health command"),
+    }
+}
+
+/// 测试 Cli 结构体解析 - Version 命令
+#[test]
+fn test_cli_parse_version_command() {
+    let cli = crates_docs::cli::Cli::try_parse_from(["crates-docs", "version"]);
+
+    assert!(cli.is_ok());
+    let cli = cli.unwrap();
+    match cli.command {
+        crates_docs::cli::Commands::Version => {}
+        _ => panic!("Expected Version command"),
+    }
+}
+
+/// 测试 Cli 全局参数 - config
+#[test]
+fn test_cli_global_config_option() {
+    let cli = crates_docs::cli::Cli::try_parse_from([
+        "crates-docs",
+        "--config",
+        "/custom/config.toml",
+        "version",
+    ]);
+
+    assert!(cli.is_ok());
+    let cli = cli.unwrap();
+    assert_eq!(cli.config, PathBuf::from("/custom/config.toml"));
+}
+
+/// 测试 Cli 全局参数 - debug
+#[test]
+fn test_cli_global_debug_option() {
+    let cli = crates_docs::cli::Cli::try_parse_from(["crates-docs", "--debug", "version"]);
+
+    assert!(cli.is_ok());
+    let cli = cli.unwrap();
+    assert!(cli.debug);
+}
+
+/// 测试 Cli 全局参数 - verbose
+#[test]
+fn test_cli_global_verbose_option() {
+    let cli = crates_docs::cli::Cli::try_parse_from(["crates-docs", "--verbose", "version"]);
+
+    assert!(cli.is_ok());
+    let cli = cli.unwrap();
+    assert!(cli.verbose);
+}
+
+/// 测试 Cli 全局参数组合
+#[test]
+fn test_cli_global_options_combined() {
+    let cli = crates_docs::cli::Cli::try_parse_from([
+        "crates-docs",
+        "--config",
+        "test.toml",
+        "--debug",
+        "--verbose",
+        "version",
+    ]);
+
+    assert!(cli.is_ok());
+    let cli = cli.unwrap();
+    assert_eq!(cli.config, PathBuf::from("test.toml"));
+    assert!(cli.debug);
+    assert!(cli.verbose);
+}
+
+/// 测试 Cli 默认配置路径
+#[test]
+fn test_cli_default_config_path() {
+    let cli = crates_docs::cli::Cli::try_parse_from(["crates-docs", "version"]);
+
+    assert!(cli.is_ok());
+    let cli = cli.unwrap();
+    assert_eq!(cli.config, PathBuf::from("config.toml"));
+    assert!(!cli.debug);
+    assert!(!cli.verbose);
+}
+
+// ============================================================================
+// config_cmd 测试
+// ============================================================================
+
+/// 测试 config 命令 - 成功生成配置文件
+#[test]
+fn test_run_config_command_success() {
+    let dir = tempfile::tempdir().unwrap();
+    let output_path = dir.path().join("test-config.toml");
+
+    let result = crates_docs::cli::run_config_command(&output_path, false);
+
+    assert!(result.is_ok());
+    assert!(output_path.exists());
+}
+
+/// 测试 config 命令 - 文件已存在但不覆盖
+#[test]
+fn test_run_config_command_file_exists_no_force() {
+    let dir = tempfile::tempdir().unwrap();
+    let output_path = dir.path().join("existing-config.toml");
+
+    // 先创建文件
+    std::fs::write(&output_path, "existing content").unwrap();
+    assert!(output_path.exists());
+
+    let result = crates_docs::cli::run_config_command(&output_path, false);
+
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("Config file already exists"));
+    assert!(err.contains("--force"));
+}
+
+/// 测试 config 命令 - 文件已存在且强制覆盖
+#[test]
+fn test_run_config_command_file_exists_with_force() {
+    let dir = tempfile::tempdir().unwrap();
+    let output_path = dir.path().join("existing-config.toml");
+
+    // 先创建文件
+    std::fs::write(&output_path, "existing content").unwrap();
+    assert!(output_path.exists());
+
+    let result = crates_docs::cli::run_config_command(&output_path, true);
+
+    assert!(result.is_ok());
+    // 验证文件被覆盖
+    let content = std::fs::read_to_string(&output_path).unwrap();
+    assert!(content.contains("name = \"crates-docs\""));
+}
+
+/// 测试 config 命令 - 创建嵌套目录
+#[test]
+fn test_run_config_command_nested_directory() {
+    let dir = tempfile::tempdir().unwrap();
+    let output_path = dir.path().join("nested/deep/config.toml");
+
+    let result = crates_docs::cli::run_config_command(&output_path, false);
+
+    assert!(result.is_ok());
+    assert!(output_path.exists());
+}
+
+// ============================================================================
+// health_cmd 测试
+// ============================================================================
+
+/// 测试 health 命令 - 默认检查类型
+#[tokio::test]
+async fn test_run_health_command_default() {
+    let result = crates_docs::cli::run_health_command("all", false).await;
+    assert!(result.is_ok());
+}
+
+/// 测试 health 命令 - 详细模式
+#[tokio::test]
+async fn test_run_health_command_verbose() {
+    let result = crates_docs::cli::run_health_command("external", true).await;
+    assert!(result.is_ok());
+}
+
+/// 测试 health 命令 - 各种检查类型
+#[tokio::test]
+async fn test_run_health_command_various_types() {
+    let check_types = ["all", "external", "internal", "docs_rs", "crates_io"];
+
+    for check_type in check_types {
+        let result = crates_docs::cli::run_health_command(check_type, false).await;
+        assert!(result.is_ok(), "Failed for check_type: {}", check_type);
+    }
+}
+
+// ============================================================================
+// version_cmd 测试
+// ============================================================================
+
+/// 测试 version 命令 - 验证输出包含版本信息
+#[test]
+fn test_run_version_command() {
+    // version 命令只是打印信息，我们验证它不会 panic
+    crates_docs::cli::run_version_command();
+}
+
+// ============================================================================
+// test_cmd 测试
+// ============================================================================
+
+/// 测试 test 命令 - 未知工具
+#[tokio::test]
+async fn test_run_test_command_unknown_tool() {
+    let result =
+        crates_docs::cli::run_test_command("unknown_tool", None, None, None, None, 10, "markdown")
+            .await;
+
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("Unknown tool"));
+}
+
+/// 测试 test 命令 - lookup_crate 缺少 crate_name
+#[tokio::test]
+async fn test_run_test_command_lookup_crate_missing_name() {
+    let result =
+        crates_docs::cli::run_test_command("lookup_crate", None, None, None, None, 10, "markdown")
+            .await;
+
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("--crate-name"));
+}
+
+/// 测试 test 命令 - search_crates 缺少 query
+#[tokio::test]
+async fn test_run_test_command_search_crates_missing_query() {
+    let result =
+        crates_docs::cli::run_test_command("search_crates", None, None, None, None, 10, "markdown")
+            .await;
+
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("--query"));
+}
+
+/// 测试 test 命令 - lookup_item 缺少参数
+#[tokio::test]
+async fn test_run_test_command_lookup_item_missing_args() {
+    // 缺少 item_path
+    let result = crates_docs::cli::run_test_command(
+        "lookup_item",
+        Some("serde"),
+        None,
+        None,
+        None,
+        10,
+        "markdown",
+    )
+    .await;
+
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("--crate-name") || err.contains("--item-path"));
+
+    // 缺少 crate_name
+    let result = crates_docs::cli::run_test_command(
+        "lookup_item",
+        None,
+        Some("Deserialize"),
+        None,
+        None,
+        10,
+        "markdown",
+    )
+    .await;
+
+    assert!(result.is_err());
+}
+
+/// 测试 test 命令 - health_check 工具
+#[tokio::test]
+async fn test_run_test_command_health_check() {
+    let result =
+        crates_docs::cli::run_test_command("health_check", None, None, None, None, 10, "markdown")
+            .await;
+
+    // health_check 应该成功执行
+    assert!(result.is_ok());
+}
+
+// ============================================================================
+// Commands 枚举测试
+// ============================================================================
+
+/// 测试 Commands 枚举变体匹配
+#[test]
+fn test_commands_enum_variants() {
+    // 验证所有命令变体都可以正确创建
+    let commands: Vec<crates_docs::cli::Commands> = vec![
+        crates_docs::cli::Commands::Serve {
+            mode: None,
+            host: None,
+            port: None,
+            enable_oauth: None,
+            oauth_client_id: None,
+            oauth_client_secret: None,
+            oauth_redirect_uri: None,
+        },
+        crates_docs::cli::Commands::Config {
+            output: PathBuf::from("config.toml"),
+            force: false,
+        },
+        crates_docs::cli::Commands::Test {
+            tool: "lookup_crate".to_string(),
+            crate_name: None,
+            item_path: None,
+            query: None,
+            version: None,
+            limit: 10,
+            format: "markdown".to_string(),
+        },
+        crates_docs::cli::Commands::Health {
+            check_type: "all".to_string(),
+            verbose: false,
+        },
+        crates_docs::cli::Commands::Version,
+    ];
+
+    // 验证每个命令都可以被正确匹配
+    for cmd in commands {
+        match cmd {
+            crates_docs::cli::Commands::Serve { .. } => {}
+            crates_docs::cli::Commands::Config { .. } => {}
+            crates_docs::cli::Commands::Test { .. } => {}
+            crates_docs::cli::Commands::Health { .. } => {}
+            crates_docs::cli::Commands::Version => {}
+        }
+    }
+}
+
+// ============================================================================
+// Cli 解析错误测试
+// ============================================================================
+
+/// 测试 Cli 解析 - 缺少子命令
+#[test]
+fn test_cli_parse_missing_subcommand() {
+    let result = crates_docs::cli::Cli::try_parse_from(["crates-docs"]);
+    assert!(result.is_err());
+}
+
+/// 测试 Cli 解析 - 无效的子命令
+#[test]
+fn test_cli_parse_invalid_subcommand() {
+    let result = crates_docs::cli::Cli::try_parse_from(["crates-docs", "invalid_command"]);
+    assert!(result.is_err());
+}
+
+/// 测试 Cli 解析 - 无效的端口号
+#[test]
+fn test_cli_parse_invalid_port() {
+    let result =
+        crates_docs::cli::Cli::try_parse_from(["crates-docs", "serve", "--port", "not_a_number"]);
+    assert!(result.is_err());
+}
+
+/// 测试 Cli 解析 - 无效的 limit
+#[test]
+fn test_cli_parse_invalid_limit() {
+    let result =
+        crates_docs::cli::Cli::try_parse_from(["crates-docs", "test", "--limit", "not_a_number"]);
+    assert!(result.is_err());
+}

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -2,6 +2,7 @@
 
 mod auth_tests;
 mod cache_tests;
+mod cli_tests;
 mod config_tests;
 mod error_tests;
 mod lib_tests;


### PR DESCRIPTION
- Modernize format strings from {} to inline {var} syntax
- Improve doc comment formatting with code backticks
- Move cli module from main.rs to lib.rs for public export
- Change load_config from async to sync function (no async ops inside)
- Update import paths from crates_docs:: to crate::