### PR TITLE
refactor: standardize error construction with field context

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -207,8 +207,9 @@ pub fn create_cache(config: &CacheConfig) -> Result<Box<dyn Cache>, crate::error
             }
             #[cfg(not(feature = "cache-memory"))]
             {
-                Err(crate::error::Error::Config(
-                    "memory cache feature is not enabled".to_string(),
+                Err(crate::error::Error::config(
+                    "cache_type",
+                    "memory cache feature is not enabled",
                 ))
             }
         }
@@ -217,22 +218,23 @@ pub fn create_cache(config: &CacheConfig) -> Result<Box<dyn Cache>, crate::error
             {
                 // Note: Redis cache requires async initialization, this returns a placeholder
                 // In practice, use the create_cache_async function
-                Err(crate::error::Error::Config(
-                    "Redis cache requires async initialization. Use create_cache_async instead."
-                        .to_string(),
+                Err(crate::error::Error::config(
+                    "cache_type",
+                    "Redis cache requires async initialization. Use create_cache_async instead.",
                 ))
             }
             #[cfg(not(feature = "cache-redis"))]
             {
-                Err(crate::error::Error::Config(
-                    "redis cache feature is not enabled".to_string(),
+                Err(crate::error::Error::config(
+                    "cache_type",
+                    "redis cache feature is not enabled",
                 ))
             }
         }
-        _ => Err(crate::error::Error::Config(format!(
-            "unsupported cache type: {}",
-            config.cache_type
-        ))),
+        _ => Err(crate::error::Error::config(
+            "cache_type",
+            format!("unsupported cache type: {}", config.cache_type),
+        )),
     }
 }
 
@@ -273,14 +275,14 @@ pub async fn create_cache_async(
             let url = config
                 .redis_url
                 .as_ref()
-                .ok_or_else(|| crate::error::Error::Config("redis_url is required".to_string()))?;
+                .ok_or_else(|| crate::error::Error::config("redis_url", "redis_url is required"))?;
             Ok(Box::new(
                 redis::RedisCache::new(url, config.key_prefix.clone()).await?,
             ))
         }
-        _ => Err(crate::error::Error::Config(format!(
-            "unsupported cache type: {}",
-            config.cache_type
-        ))),
+        _ => Err(crate::error::Error::config(
+            "cache_type",
+            format!("unsupported cache type: {}", config.cache_type),
+        )),
     }
 }

--- a/src/cache/redis.rs
+++ b/src/cache/redis.rs
@@ -41,20 +41,22 @@ impl RedisCache {
     /// Returns an error if Redis connection fails or ping test fails
     pub async fn new(url: &str, key_prefix: String) -> Result<Self, Error> {
         let client = redis::Client::open(url)
-            .map_err(|e| Error::Cache(format!("Redis connection failed: {e}")))?;
+            .map_err(|e| Error::cache("connect", None, format!("failed: {e}")))?;
 
         // Create multiplexed connection (can be shared across multiple operations)
         let conn = client
             .get_multiplexed_async_connection()
             .await
-            .map_err(|e| Error::Cache(format!("Redis connection creation failed: {e}")))?;
+            .map_err(|e| {
+                Error::cache("connect", None, format!("connection creation failed: {e}"))
+            })?;
 
         // Simple ping test
         let mut ping_conn = conn.clone();
         let _: String = redis::cmd("PING")
             .query_async(&mut ping_conn)
             .await
-            .map_err(|e| Error::Cache(format!("Redis ping failed: {e}")))?;
+            .map_err(|e| Error::cache("ping", None, format!("failed: {e}")))?;
 
         Ok(Self { conn, key_prefix })
     }
@@ -120,7 +122,7 @@ impl super::Cache for RedisCache {
                 .await
         };
 
-        result.map_err(|e| Error::Cache(format!("Redis SET failed for key '{key}': {e}")))
+        result.map_err(|e| Error::cache("set", Some(key.clone()), format!("failed: {e}")))
     }
 
     async fn delete(&self, key: &str) -> crate::error::Result<()> {
@@ -132,7 +134,7 @@ impl super::Cache for RedisCache {
             .query_async(&mut conn)
             .await;
 
-        result.map_err(|e| Error::Cache(format!("Redis DEL failed for key '{key}': {e}")))
+        result.map_err(|e| Error::cache("delete", Some(key.to_string()), format!("failed: {e}")))
     }
 
     async fn clear(&self) -> crate::error::Result<()> {
@@ -165,9 +167,11 @@ impl super::Cache for RedisCache {
                         match del_result {
                             Ok(deleted) => total_deleted += deleted,
                             Err(e) => {
-                                return Err(Error::Cache(format!(
-                                    "Redis DEL during clear failed: {e}"
-                                )));
+                                return Err(Error::cache(
+                                    "clear",
+                                    None,
+                                    format!("DEL failed: {e}"),
+                                ));
                             }
                         }
                     }
@@ -179,7 +183,7 @@ impl super::Cache for RedisCache {
                     }
                 }
                 Err(e) => {
-                    return Err(Error::Cache(format!("Redis SCAN during clear failed: {e}")));
+                    return Err(Error::cache("clear", None, format!("SCAN failed: {e}")));
                 }
             }
         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -271,11 +271,12 @@ impl AppConfig {
     ///
     /// Returns an error if file does not exist, cannot be read, or format is invalid
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, crate::error::Error> {
-        let content = fs::read_to_string(path)
-            .map_err(|e| crate::error::Error::Config(format!("Failed to read config file: {e}")))?;
+        let content = fs::read_to_string(path).map_err(|e| {
+            crate::error::Error::config("file", format!("Failed to read config file: {e}"))
+        })?;
 
         let config: Self = toml::from_str(&content).map_err(|e| {
-            crate::error::Error::Config(format!("Failed to parse config file: {e}"))
+            crate::error::Error::parse("config", None, format!("Failed to parse config file: {e}"))
         })?;
 
         config.validate()?;
@@ -289,18 +290,21 @@ impl AppConfig {
     /// Returns an error if configuration cannot be serialized, directory cannot be created, or file cannot be written
     pub fn save_to_file<P: AsRef<Path>>(&self, path: P) -> Result<(), crate::error::Error> {
         let content = toml::to_string_pretty(self).map_err(|e| {
-            crate::error::Error::Config(format!("Failed to serialize configuration: {e}"))
+            crate::error::Error::config(
+                "serialization",
+                format!("Failed to serialize configuration: {e}"),
+            )
         })?;
 
         // Ensure directory exists
         if let Some(parent) = path.as_ref().parent() {
             fs::create_dir_all(parent).map_err(|e| {
-                crate::error::Error::Config(format!("Failed to create directory: {e}"))
+                crate::error::Error::config("directory", format!("Failed to create directory: {e}"))
             })?;
         }
 
         fs::write(path, content).map_err(|e| {
-            crate::error::Error::Config(format!("Failed to write config file: {e}"))
+            crate::error::Error::config("file", format!("Failed to write config file: {e}"))
         })?;
 
         Ok(())
@@ -314,70 +318,75 @@ impl AppConfig {
     pub fn validate(&self) -> Result<(), crate::error::Error> {
         // Validate server configuration
         if self.server.host.is_empty() {
-            return Err(crate::error::Error::Config(
-                "Server host cannot be empty".to_string(),
-            ));
+            return Err(crate::error::Error::config("host", "cannot be empty"));
         }
 
         if self.server.port == 0 {
-            return Err(crate::error::Error::Config(
-                "Server port cannot be 0".to_string(),
-            ));
+            return Err(crate::error::Error::config("port", "cannot be 0"));
         }
 
         if self.server.max_connections == 0 {
-            return Err(crate::error::Error::Config(
-                "Maximum connections cannot be 0".to_string(),
+            return Err(crate::error::Error::config(
+                "max_connections",
+                "cannot be 0",
             ));
         }
 
         // Validate transport mode
         let valid_modes = ["stdio", "http", "sse", "hybrid"];
         if !valid_modes.contains(&self.server.transport_mode.as_str()) {
-            return Err(crate::error::Error::Config(format!(
-                "Invalid transport mode: {}, valid values: {:?}",
-                self.server.transport_mode, valid_modes
-            )));
+            return Err(crate::error::Error::config(
+                "transport_mode",
+                format!(
+                    "Invalid transport mode: {}, valid values: {:?}",
+                    self.server.transport_mode, valid_modes
+                ),
+            ));
         }
 
         // Validate log level
         let valid_levels = ["trace", "debug", "info", "warn", "error"];
         if !valid_levels.contains(&self.logging.level.as_str()) {
-            return Err(crate::error::Error::Config(format!(
-                "Invalid log level: {}, valid values: {:?}",
-                self.logging.level, valid_levels
-            )));
+            return Err(crate::error::Error::config(
+                "log_level",
+                format!(
+                    "Invalid log level: {}, valid values: {:?}",
+                    self.logging.level, valid_levels
+                ),
+            ));
         }
 
         // Validate performance configuration
         if self.performance.http_client_pool_size == 0 {
-            return Err(crate::error::Error::Config(
-                "HTTP client connection pool size cannot be 0".to_string(),
+            return Err(crate::error::Error::config(
+                "http_client_pool_size",
+                "cannot be 0",
             ));
         }
 
         if self.performance.http_client_pool_idle_timeout_secs == 0 {
-            return Err(crate::error::Error::Config(
-                "HTTP client pool idle timeout cannot be 0".to_string(),
+            return Err(crate::error::Error::config(
+                "http_client_pool_idle_timeout_secs",
+                "cannot be 0",
             ));
         }
 
         if self.performance.http_client_connect_timeout_secs == 0 {
-            return Err(crate::error::Error::Config(
-                "HTTP client connection timeout cannot be 0".to_string(),
+            return Err(crate::error::Error::config(
+                "http_client_connect_timeout_secs",
+                "cannot be 0",
             ));
         }
 
         if self.performance.http_client_timeout_secs == 0 {
-            return Err(crate::error::Error::Config(
-                "HTTP client request timeout cannot be 0".to_string(),
+            return Err(crate::error::Error::config(
+                "http_client_timeout_secs",
+                "cannot be 0",
             ));
         }
 
         if self.performance.cache_max_size == 0 {
-            return Err(crate::error::Error::Config(
-                "Maximum cache size cannot be 0".to_string(),
-            ));
+            return Err(crate::error::Error::config("cache_max_size", "cannot be 0"));
         }
 
         // Validate OAuth configuration
@@ -408,7 +417,7 @@ impl AppConfig {
         if let Ok(port) = std::env::var("CRATES_DOCS_PORT") {
             config.server.port = port
                 .parse()
-                .map_err(|e| crate::error::Error::Config(format!("Invalid port: {e}")))?;
+                .map_err(|e| crate::error::Error::config("port", format!("Invalid port: {e}")))?;
         }
 
         if let Ok(mode) = std::env::var("CRATES_DOCS_TRANSPORT_MODE") {

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -15,6 +15,15 @@
 //!     // 可能失败的操作
 //!     Ok("success".to_string())
 //! }
+//!
+//! // 创建结构化错误
+//! fn create_config_error() -> Error {
+//!     Error::config("field_name", "invalid value")
+//! }
+//!
+//! fn create_cache_error() -> Error {
+//!     Error::cache("set", Some("key".to_string()), "operation failed")
+//! }
 //! ```
 
 use thiserror::Error;
@@ -24,33 +33,76 @@ use thiserror::Error;
 /// 包含所有可能的错误变体，使用 `thiserror` 派生宏实现 `std::error::Error`。
 #[derive(Error, Debug)]
 pub enum Error {
-    /// 初始化错误
-    #[error("Initialization failed: {0}")]
-    Initialization(String),
-
-    /// 配置错误
-    #[error("Configuration error: {0}")]
-    Config(String),
-
     /// HTTP 请求错误
-    #[error("HTTP request failed: {0}")]
-    HttpRequest(String),
+    #[error("HTTP request failed: {method} {url} - status {status}: {message}")]
+    HttpRequest {
+        /// HTTP 方法
+        method: String,
+        /// 请求 URL
+        url: String,
+        /// HTTP 状态码
+        status: u16,
+        /// 错误消息
+        message: String,
+    },
 
-    /// 解析错误
-    #[error("Parse failed: {0}")]
-    Parse(String),
-
-    /// 缓存错误
-    #[error("Cache operation failed: {0}")]
-    Cache(String),
-
-    /// 认证错误
-    #[error("Authentication failed: {0}")]
-    Auth(String),
+    /// 缓存操作错误
+    #[error("Cache operation '{operation}' failed for key '{key}': {message}")]
+    Cache {
+        /// 操作类型 ("get", "set", "delete", "clear")
+        operation: String,
+        /// 缓存键
+        key: String,
+        /// 错误消息
+        message: String,
+    },
 
     /// MCP 协议错误
-    #[error("MCP protocol error: {0}")]
-    Mcp(String),
+    #[error("MCP protocol error in '{context}': {message}")]
+    Mcp {
+        /// 错误发生的上下文
+        context: String,
+        /// 错误消息
+        message: String,
+    },
+
+    /// 初始化错误
+    #[error("Initialization failed for '{component}': {message}")]
+    Initialization {
+        /// 初始化失败的组件
+        component: String,
+        /// 错误消息
+        message: String,
+    },
+
+    /// 配置错误
+    #[error("Configuration error for '{field}': {message}")]
+    Config {
+        /// 配置字段名
+        field: String,
+        /// 错误消息
+        message: String,
+    },
+
+    /// 解析错误
+    #[error("Parse failed for '{input}'{position}: {message}")]
+    Parse {
+        /// 解析的输入源
+        input: String,
+        /// 位置信息
+        position: String,
+        /// 错误消息
+        message: String,
+    },
+
+    /// 认证错误
+    #[error("Authentication failed for '{provider}': {message}")]
+    Auth {
+        /// 认证提供者
+        provider: String,
+        /// 错误消息
+        message: String,
+    },
 
     /// IO 错误
     #[error("IO error: {0}")]
@@ -77,6 +129,127 @@ pub enum Error {
 ///
 /// `Result<T>` 是 `std::result::Result<T, Error>` 的简写。
 pub type Result<T> = std::result::Result<T, Error>;
+
+impl Error {
+    /// 创建 HTTP 请求错误
+    ///
+    /// # 参数
+    ///
+    /// * `method` - HTTP 方法 (GET, POST, 等)
+    /// * `url` - 请求的 URL
+    /// * `status` - HTTP 状态码
+    /// * `message` - 错误消息
+    #[must_use]
+    pub fn http_request(
+        method: impl Into<String>,
+        url: impl Into<String>,
+        status: u16,
+        message: impl Into<String>,
+    ) -> Self {
+        Self::HttpRequest {
+            method: method.into(),
+            url: url.into(),
+            status,
+            message: message.into(),
+        }
+    }
+
+    /// 创建缓存操作错误
+    ///
+    /// # 参数
+    ///
+    /// * `operation` - 操作类型 ("get", "set", "delete", "clear")
+    /// * `key` - 相关的缓存键（可选）
+    /// * `message` - 错误消息
+    #[must_use]
+    pub fn cache(
+        operation: impl Into<String>,
+        key: Option<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self::Cache {
+            operation: operation.into(),
+            key: key.unwrap_or_else(|| "N/A".to_string()),
+            message: message.into(),
+        }
+    }
+
+    /// 创建 MCP 协议错误
+    ///
+    /// # 参数
+    ///
+    /// * `context` - 错误发生的上下文
+    /// * `message` - 错误消息
+    #[must_use]
+    pub fn mcp(context: impl Into<String>, message: impl Into<String>) -> Self {
+        Self::Mcp {
+            context: context.into(),
+            message: message.into(),
+        }
+    }
+
+    /// 创建初始化错误
+    ///
+    /// # 参数
+    ///
+    /// * `component` - 初始化失败的组件
+    /// * `message` - 错误消息
+    #[must_use]
+    pub fn initialization(component: impl Into<String>, message: impl Into<String>) -> Self {
+        Self::Initialization {
+            component: component.into(),
+            message: message.into(),
+        }
+    }
+
+    /// 创建配置错误
+    ///
+    /// # 参数
+    ///
+    /// * `field` - 配置字段名
+    /// * `message` - 错误消息
+    #[must_use]
+    pub fn config(field: impl Into<String>, message: impl Into<String>) -> Self {
+        Self::Config {
+            field: field.into(),
+            message: message.into(),
+        }
+    }
+
+    /// 创建解析错误
+    ///
+    /// # 参数
+    ///
+    /// * `input` - 解析的输入源
+    /// * `position` - 错误位置（可选）
+    /// * `message` - 错误消息
+    #[must_use]
+    pub fn parse(
+        input: impl Into<String>,
+        position: Option<usize>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self::Parse {
+            input: input.into(),
+            position: position.map_or_else(String::new, |p| format!(" at position {p}")),
+            message: message.into(),
+        }
+    }
+
+    /// 创建认证错误
+    ///
+    /// # 参数
+    ///
+    /// * `provider` - 认证提供者
+    /// * `message` - 错误消息
+    #[must_use]
+    pub fn auth(provider: impl Into<String>, message: impl Into<String>) -> Self {
+        Self::Auth {
+            provider: provider.into(),
+            message: message.into(),
+        }
+    }
+}
 
 impl From<Box<dyn std::error::Error + Send + Sync>> for Error {
     fn from(err: Box<dyn std::error::Error + Send + Sync>) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@ pub fn init_logging(debug: bool) -> Result<()> {
         .with(filter)
         .with(fmt_layer)
         .try_init()
-        .map_err(|e| error::Error::Initialization(e.to_string()))?;
+        .map_err(|e| error::Error::initialization("logging", e.to_string()))?;
 
     Ok(())
 }
@@ -103,6 +103,34 @@ pub fn init_logging(debug: bool) -> Result<()> {
 /// Returns an error if logging system initialization fails
 pub fn init_logging_with_config(config: &crate::config::LoggingConfig) -> Result<()> {
     use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+
+    /// Helper macro to create fmt layer with standard configuration
+    macro_rules! fmt_layer {
+        () => {
+            fmt::layer()
+                .with_target(true)
+                .with_thread_ids(true)
+                .with_thread_names(true)
+                .compact()
+        };
+        ($writer:expr) => {
+            fmt::layer()
+                .with_writer($writer)
+                .with_target(true)
+                .with_thread_ids(true)
+                .with_thread_names(true)
+                .compact()
+        };
+    }
+
+    /// Helper macro to initialize subscriber with error handling
+    macro_rules! try_init {
+        ($subscriber:expr) => {
+            $subscriber
+                .try_init()
+                .map_err(|e| error::Error::initialization("logging", e.to_string()))?
+        };
+    }
 
     // Parse log level
     let level = match config.level.to_lowercase().as_str() {
@@ -119,107 +147,62 @@ pub fn init_logging_with_config(config: &crate::config::LoggingConfig) -> Result
     match (config.enable_console, config.enable_file, &config.file_path) {
         // Enable both console and file logging
         (true, true, Some(file_path)) => {
-            // Determine log directory
-            let log_dir = std::path::Path::new(file_path)
-                .parent()
-                .filter(|p| !p.as_os_str().is_empty())
-                .unwrap_or_else(|| std::path::Path::new("."));
-            let log_file_name = std::path::Path::new(file_path)
-                .file_name()
-                .unwrap_or(std::ffi::OsStr::new("crates-docs.log"));
+            let (log_dir, log_file_name) = parse_log_path(file_path);
+            ensure_log_directory(&log_dir)?;
+            let file_appender = tracing_appender::rolling::daily(&log_dir, log_file_name);
 
-            // Ensure directory exists
-            std::fs::create_dir_all(log_dir).map_err(|e| {
-                error::Error::Initialization(format!("Failed to create log directory: {e}"))
-            })?;
-
-            // Create file log layer
-            let file_appender = tracing_appender::rolling::daily(log_dir, log_file_name);
-
-            tracing_subscriber::registry()
+            try_init!(tracing_subscriber::registry()
                 .with(filter)
-                .with(
-                    fmt::layer()
-                        .with_target(true)
-                        .with_thread_ids(true)
-                        .with_thread_names(true)
-                        .compact(),
-                )
-                .with(
-                    fmt::layer()
-                        .with_writer(file_appender)
-                        .with_target(true)
-                        .with_thread_ids(true)
-                        .with_thread_names(true)
-                        .compact(),
-                )
-                .try_init()
-                .map_err(|e| error::Error::Initialization(e.to_string()))?;
+                .with(fmt_layer!())
+                .with(fmt_layer!(file_appender)));
         }
 
         // Enable console logging only
         (true, _, _) | (false, false, _) => {
-            tracing_subscriber::registry()
+            try_init!(tracing_subscriber::registry()
                 .with(filter)
-                .with(
-                    fmt::layer()
-                        .with_target(true)
-                        .with_thread_ids(true)
-                        .with_thread_names(true)
-                        .compact(),
-                )
-                .try_init()
-                .map_err(|e| error::Error::Initialization(e.to_string()))?;
+                .with(fmt_layer!()));
         }
 
         // Enable file logging only
         (false, true, Some(file_path)) => {
-            // Determine log directory
-            let log_dir = std::path::Path::new(file_path)
-                .parent()
-                .filter(|p| !p.as_os_str().is_empty())
-                .unwrap_or_else(|| std::path::Path::new("."));
-            let log_file_name = std::path::Path::new(file_path)
-                .file_name()
-                .unwrap_or(std::ffi::OsStr::new("crates-docs.log"));
+            let (log_dir, log_file_name) = parse_log_path(file_path);
+            ensure_log_directory(&log_dir)?;
+            let file_appender = tracing_appender::rolling::daily(&log_dir, log_file_name);
 
-            // Ensure directory exists
-            std::fs::create_dir_all(log_dir).map_err(|e| {
-                error::Error::Initialization(format!("Failed to create log directory: {e}"))
-            })?;
-
-            // Create file log layer
-            let file_appender = tracing_appender::rolling::daily(log_dir, log_file_name);
-
-            tracing_subscriber::registry()
+            try_init!(tracing_subscriber::registry()
                 .with(filter)
-                .with(
-                    fmt::layer()
-                        .with_writer(file_appender)
-                        .with_target(true)
-                        .with_thread_ids(true)
-                        .with_thread_names(true)
-                        .compact(),
-                )
-                .try_init()
-                .map_err(|e| error::Error::Initialization(e.to_string()))?;
+                .with(fmt_layer!(file_appender)));
         }
 
         // Other cases, use default console logging
         _ => {
-            tracing_subscriber::registry()
+            try_init!(tracing_subscriber::registry()
                 .with(filter)
-                .with(
-                    fmt::layer()
-                        .with_target(true)
-                        .with_thread_ids(true)
-                        .with_thread_names(true)
-                        .compact(),
-                )
-                .try_init()
-                .map_err(|e| error::Error::Initialization(e.to_string()))?;
+                .with(fmt_layer!()));
         }
     }
 
     Ok(())
+}
+
+/// Parse log file path into directory and file name components
+fn parse_log_path(file_path: &str) -> (std::path::PathBuf, std::ffi::OsString) {
+    let path = std::path::Path::new(file_path);
+    let log_dir = path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .map_or_else(|| std::path::PathBuf::from("."), std::path::PathBuf::from);
+    let log_file_name = path.file_name().map_or_else(
+        || std::ffi::OsString::from("crates-docs.log"),
+        std::ffi::OsString::from,
+    );
+    (log_dir, log_file_name)
+}
+
+/// Ensure log directory exists
+fn ensure_log_directory(log_dir: &std::path::Path) -> Result<()> {
+    std::fs::create_dir_all(log_dir).map_err(|e| {
+        error::Error::initialization("log_directory", format!("Failed to create: {e}"))
+    })
 }

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -132,40 +132,40 @@ impl OAuthConfig {
         }
 
         if self.client_id.is_none() {
-            return Err(Error::Config("client_id is required".to_string()));
+            return Err(Error::config("client_id", "is required"));
         }
 
         if self.client_secret.is_none() {
-            return Err(Error::Config("client_secret is required".to_string()));
+            return Err(Error::config("client_secret", "is required"));
         }
 
         if self.redirect_uri.is_none() {
-            return Err(Error::Config("redirect_uri is required".to_string()));
+            return Err(Error::config("redirect_uri", "is required"));
         }
 
         if self.authorization_endpoint.is_none() {
-            return Err(Error::Config(
-                "authorization_endpoint is required".to_string(),
-            ));
+            return Err(Error::config("authorization_endpoint", "is required"));
         }
 
         if self.token_endpoint.is_none() {
-            return Err(Error::Config("token_endpoint is required".to_string()));
+            return Err(Error::config("token_endpoint", "is required"));
         }
 
         // Validate URLs
         if let Some(uri) = &self.redirect_uri {
-            Url::parse(uri).map_err(|e| Error::Config(format!("Invalid redirect_uri: {e}")))?;
+            Url::parse(uri)
+                .map_err(|e| Error::config("redirect_uri", format!("Invalid URL: {e}")))?;
         }
 
         if let Some(endpoint) = &self.authorization_endpoint {
-            Url::parse(endpoint)
-                .map_err(|e| Error::Config(format!("Invalid authorization_endpoint: {e}")))?;
+            Url::parse(endpoint).map_err(|e| {
+                Error::config("authorization_endpoint", format!("Invalid URL: {e}"))
+            })?;
         }
 
         if let Some(endpoint) = &self.token_endpoint {
             Url::parse(endpoint)
-                .map_err(|e| Error::Config(format!("Invalid token_endpoint: {e}")))?;
+                .map_err(|e| Error::config("token_endpoint", format!("Invalid URL: {e}")))?;
         }
 
         Ok(())
@@ -175,7 +175,7 @@ impl OAuthConfig {
     #[cfg(feature = "auth")]
     pub fn to_mcp_config(&self) -> Result<()> {
         if !self.enabled {
-            return Err(Error::Config("OAuth is not enabled".to_string()));
+            return Err(Error::config("oauth", "is not enabled"));
         }
 
         // Temporarily return empty result, to be implemented when OAuth feature is complete
@@ -185,7 +185,7 @@ impl OAuthConfig {
     /// Convert to rust-mcp-sdk `OAuthConfig`
     #[cfg(not(feature = "auth"))]
     pub fn to_mcp_config(&self) -> Result<()> {
-        Err(Error::Config("OAuth feature is not enabled".to_string()))
+        Err(Error::config("oauth", "feature is not enabled"))
     }
 }
 

--- a/src/server/transport.rs
+++ b/src/server/transport.rs
@@ -72,7 +72,7 @@ pub async fn run_stdio_server(server: &CratesDocsServer) -> Result<()> {
 
     // Create Stdio transport
     let transport = StdioTransport::new(TransportOptions::default())
-        .map_err(|e| crate::error::Error::Mcp(e.to_string()))?;
+        .map_err(|e| crate::error::Error::mcp("transport", e.to_string()))?;
 
     // Create MCP server
     let mcp_server: Arc<rust_mcp_sdk::mcp_server::ServerRuntime> =
@@ -89,7 +89,7 @@ pub async fn run_stdio_server(server: &CratesDocsServer) -> Result<()> {
     mcp_server
         .start()
         .await
-        .map_err(|e: McpSdkError| crate::error::Error::Mcp(e.to_string()))?;
+        .map_err(|e: McpSdkError| crate::error::Error::mcp("server_start", e.to_string()))?;
 
     Ok(())
 }
@@ -158,7 +158,7 @@ pub async fn run_http_server(server: &CratesDocsServer) -> Result<()> {
     mcp_server
         .start()
         .await
-        .map_err(|e: McpSdkError| crate::error::Error::Mcp(e.to_string()))?;
+        .map_err(|e: McpSdkError| crate::error::Error::mcp("server_start", e.to_string()))?;
 
     Ok(())
 }
@@ -227,7 +227,7 @@ pub async fn run_sse_server(server: &CratesDocsServer) -> Result<()> {
     mcp_server
         .start()
         .await
-        .map_err(|e: McpSdkError| crate::error::Error::Mcp(e.to_string()))?;
+        .map_err(|e: McpSdkError| crate::error::Error::mcp("server_start", e.to_string()))?;
 
     Ok(())
 }
@@ -296,7 +296,7 @@ pub async fn run_hybrid_server(server: &CratesDocsServer) -> Result<()> {
     mcp_server
         .start()
         .await
-        .map_err(|e: McpSdkError| crate::error::Error::Mcp(e.to_string()))?;
+        .map_err(|e: McpSdkError| crate::error::Error::mcp("server_start", e.to_string()))?;
 
     Ok(())
 }

--- a/src/tools/docs/mod.rs
+++ b/src/tools/docs/mod.rs
@@ -92,7 +92,10 @@ impl DocService {
         let client = crate::utils::create_http_client_from_config(&perf_config)
             .build()
             .map_err(|e| {
-                crate::error::Error::Initialization(format!("Failed to create HTTP client: {e}"))
+                crate::error::Error::initialization(
+                    "http_client",
+                    format!("Failed to create HTTP client: {e}"),
+                )
             })?;
         Ok(Self {
             client,
@@ -122,7 +125,10 @@ impl DocService {
         let client = crate::utils::create_http_client_from_config(perf_config)
             .build()
             .map_err(|e| {
-                crate::error::Error::Initialization(format!("Failed to create HTTP client: {e}"))
+                crate::error::Error::initialization(
+                    "http_client",
+                    format!("Failed to create HTTP client: {e}"),
+                )
             })?;
         Ok(Self {
             client,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -144,7 +144,7 @@ impl HttpClientBuilder {
 
         builder
             .build()
-            .map_err(|e| Error::HttpRequest(e.to_string()))
+            .map_err(|e| Error::http_request("BUILD", "client", 0, e.to_string()))
     }
 
     /// Build HTTP client with retry support

--- a/tests/unit/auth_tests.rs
+++ b/tests/unit/auth_tests.rs
@@ -107,10 +107,7 @@ fn test_oauth_config_validate_missing_redirect_uri() {
     };
     let result = config.validate();
     assert!(result.is_err());
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains("redirect_uri is required"));
+    assert!(result.unwrap_err().to_string().contains("redirect_uri"));
 }
 
 #[test]
@@ -129,7 +126,7 @@ fn test_oauth_config_validate_invalid_urls() {
         .validate()
         .unwrap_err()
         .to_string()
-        .contains("Invalid redirect_uri"));
+        .contains("redirect_uri"));
 
     config.redirect_uri = Some("http://localhost/callback".to_string());
     config.authorization_endpoint = Some("bad-url".to_string());
@@ -137,7 +134,7 @@ fn test_oauth_config_validate_invalid_urls() {
         .validate()
         .unwrap_err()
         .to_string()
-        .contains("Invalid authorization_endpoint"));
+        .contains("authorization_endpoint"));
 
     config.authorization_endpoint = Some("https://example.com/auth".to_string());
     config.token_endpoint = Some("bad-url".to_string());
@@ -145,7 +142,7 @@ fn test_oauth_config_validate_invalid_urls() {
         .validate()
         .unwrap_err()
         .to_string()
-        .contains("Invalid token_endpoint"));
+        .contains("token_endpoint"));
 }
 
 // ============================================================================
@@ -177,7 +174,12 @@ fn test_oauth_to_mcp_config_without_feature() {
     // 默认 enabled=false，应返回错误
     assert!(result.is_err());
     if let Err(e) = result {
-        assert!(e.to_string().contains("OAuth is not enabled"));
+        // 结构化错误消息格式: "Configuration error for 'oauth': is not enabled"
+        let err_msg = e.to_string();
+        assert!(
+            err_msg.contains("oauth") && err_msg.contains("not enabled"),
+            "Expected error message to contain 'oauth' and 'not enabled', got: {err_msg}"
+        );
     }
 }
 
@@ -189,7 +191,7 @@ fn test_oauth_to_mcp_config_without_feature() {
     // feature 未启用，应返回错误
     assert!(result.is_err());
     if let Err(e) = result {
-        assert!(e.to_string().contains("OAuth feature is not enabled"));
+        assert!(e.to_string().contains("oauth"));
     }
 }
 

--- a/tests/unit/config_tests.rs
+++ b/tests/unit/config_tests.rs
@@ -13,7 +13,7 @@ fn test_config_validation_empty_host() {
     config.server.host = "".to_string();
     let result = config.validate();
     assert!(result.is_err());
-    assert!(result.unwrap_err().to_string().contains("Server host"));
+    assert!(result.unwrap_err().to_string().contains("host"));
 }
 
 #[test]

--- a/tests/unit/error_tests.rs
+++ b/tests/unit/error_tests.rs
@@ -48,26 +48,26 @@ fn test_error_from_anyhow_error() {
 
 #[test]
 fn test_error_display() {
-    let err = Error::Config("test config error".to_string());
+    let err = Error::config("field", "test config error");
     assert!(err.to_string().contains("test config error"));
 
-    let err = Error::Cache("test cache error".to_string());
+    let err = Error::cache("get", Some("key".to_string()), "test cache error");
     assert!(err.to_string().contains("test cache error"));
 
-    let err = Error::Mcp("test mcp error".to_string());
+    let err = Error::mcp("context", "test mcp error");
     assert!(err.to_string().contains("test mcp error"));
 }
 
 #[test]
 fn test_error_variants_display() {
     // 测试各种错误类型的 Display
-    let err = Error::Config("config error".to_string());
+    let err = Error::config("field", "config error");
     assert!(!err.to_string().is_empty());
 
-    let err = Error::Cache("cache error".to_string());
+    let err = Error::cache("get", None, "cache error");
     assert!(!err.to_string().is_empty());
 
-    let err = Error::HttpRequest("http error".to_string());
+    let err = Error::http_request("GET", "https://example.com", 500, "http error");
     assert!(!err.to_string().is_empty());
 
     let err = Error::Json(serde_json::from_str::<serde_json::Value>("bad").unwrap_err());
@@ -79,16 +79,16 @@ fn test_error_variants_display() {
     let err = Error::Url(url::ParseError::EmptyHost);
     assert!(!err.to_string().is_empty());
 
-    let err = Error::Mcp("mcp error".to_string());
+    let err = Error::mcp("context", "mcp error");
     assert!(!err.to_string().is_empty());
 
-    let err = Error::Initialization("init error".to_string());
+    let err = Error::initialization("component", "init error");
     assert!(!err.to_string().is_empty());
 
-    let err = Error::Auth("auth error".to_string());
+    let err = Error::auth("provider", "auth error");
     assert!(!err.to_string().is_empty());
 
-    let err = Error::Parse("parse error".to_string());
+    let err = Error::parse("input", None, "parse error");
     assert!(!err.to_string().is_empty());
 
     let err = Error::Other("other error".to_string());

--- a/tests/unit/lib_tests.rs
+++ b/tests/unit/lib_tests.rs
@@ -26,7 +26,7 @@ fn test_name_constant() {
 
 #[test]
 fn test_error_reexport() {
-    let err = crates_docs::Error::Config("test".to_string());
+    let err = crates_docs::Error::config("field", "test");
     assert!(!err.to_string().is_empty());
 }
 

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -151,7 +151,7 @@ fn test_config_validation_empty_host() {
     config.server.host = "".to_string();
     let result = config.validate();
     assert!(result.is_err());
-    assert!(result.unwrap_err().to_string().contains("Server host"));
+    assert!(result.unwrap_err().to_string().contains("host"));
 }
 
 /// 测试配置验证 - 端口为 0
@@ -305,14 +305,14 @@ fn test_error_conversions() {
 fn test_error_display() {
     use crates_docs::error::Error;
 
-    let error = Error::Config("test config error".to_string());
+    let error = Error::config("test_field", "test config error");
     assert!(error.to_string().contains("Configuration error"));
     assert!(error.to_string().contains("test config error"));
 
-    let error = Error::Initialization("test init error".to_string());
+    let error = Error::initialization("test_component", "test init error");
     assert!(error.to_string().contains("Initialization failed"));
 
-    let error = Error::HttpRequest("test http error".to_string());
+    let error = Error::http_request("GET", "https://example.com", 500, "test http error");
     assert!(error.to_string().contains("HTTP request failed"));
 }
 
@@ -762,30 +762,27 @@ fn test_error_from_anyhow_error() {
 fn test_error_variants_display() {
     use crates_docs::Error;
 
-    let variants = [
+    let variants: Vec<(Error, &str)> = vec![
         (
-            Error::Initialization("init failed".to_string()),
+            Error::initialization("component", "init failed"),
             "Initialization failed",
         ),
+        (Error::config("field", "bad config"), "Configuration error"),
         (
-            Error::Config("bad config".to_string()),
-            "Configuration error",
-        ),
-        (
-            Error::HttpRequest("request failed".to_string()),
+            Error::http_request("GET", "https://example.com", 500, "request failed"),
             "HTTP request failed",
         ),
-        (Error::Parse("parse error".to_string()), "Parse failed"),
+        (Error::parse("input", None, "parse error"), "Parse failed"),
         (
-            Error::Cache("cache error".to_string()),
-            "Cache operation failed",
+            Error::cache("get", Some("key".to_string()), "cache error"),
+            "Cache operation",
         ),
         (
-            Error::Auth("auth failed".to_string()),
+            Error::auth("provider", "auth failed"),
             "Authentication failed",
         ),
         (
-            Error::Mcp("protocol error".to_string()),
+            Error::mcp("context", "protocol error"),
             "MCP protocol error",
         ),
         (Error::Other("unknown error".to_string()), "Unknown error"),
@@ -1357,10 +1354,7 @@ fn test_config_validate_with_oauth_enabled_and_invalid_oauth() {
 
     let result = config.validate();
     assert!(result.is_err());
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains("client_id is required"));
+    assert!(result.unwrap_err().to_string().contains("client_id"));
 }
 
 #[test]
@@ -1444,10 +1438,7 @@ fn test_oauth_config_validate_missing_redirect_uri() {
 
     let result = config.validate();
     assert!(result.is_err());
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains("redirect_uri is required"));
+    assert!(result.unwrap_err().to_string().contains("redirect_uri"));
 }
 
 #[test]
@@ -1468,7 +1459,7 @@ fn test_oauth_config_validate_invalid_urls() {
         .validate()
         .unwrap_err()
         .to_string()
-        .contains("Invalid redirect_uri"));
+        .contains("redirect_uri"));
 
     config.redirect_uri = Some("http://localhost/callback".to_string());
     config.authorization_endpoint = Some("bad-url".to_string());
@@ -1476,7 +1467,7 @@ fn test_oauth_config_validate_invalid_urls() {
         .validate()
         .unwrap_err()
         .to_string()
-        .contains("Invalid authorization_endpoint"));
+        .contains("authorization_endpoint"));
 
     config.authorization_endpoint = Some("https://example.com/auth".to_string());
     config.token_endpoint = Some("bad-url".to_string());
@@ -1484,7 +1475,7 @@ fn test_oauth_config_validate_invalid_urls() {
         .validate()
         .unwrap_err()
         .to_string()
-        .contains("Invalid token_endpoint"));
+        .contains("token_endpoint"));
 }
 
 #[test]
@@ -1512,9 +1503,9 @@ fn test_oauth_to_mcp_config() {
     let result = config.to_mcp_config();
     // 无论是否启用 auth feature，默认配置（enabled=false）应该返回错误
     assert!(result.is_err());
-    // 错误消息可能是 "OAuth is not enabled" 或 "OAuth feature is not enabled"
+    // 错误消息包含 "oauth"
     let err_msg = result.unwrap_err().to_string();
-    assert!(err_msg.contains("OAuth") && err_msg.contains("not enabled"));
+    assert!(err_msg.contains("oauth"));
 }
 
 #[test]


### PR DESCRIPTION
Replace Error::Config(String) and Error::Cache(String) constructors with structured variants that include the relevant field name, making errors more informative for debugging.