### PR TITLE
feat(ci): add cross-compiled binaries for Docker release builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -363,12 +363,80 @@ jobs:
 
         cargo publish
 
+  # Docker 二进制预编译 - 只在推送版本标签时运行
+  build-docker-binaries:
+    name: Build Docker Binaries
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [check, docker]
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            arch: amd64
+            use_cross: false
+          - target: aarch64-unknown-linux-musl
+            arch: arm64
+            use_cross: true
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+      
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: ${{ matrix.target }}
+      
+    - name: Cache cargo
+      uses: actions/cache@v5
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-${{ matrix.target }}-docker-cargo-${{ hashFiles('**/Cargo.toml') }}
+      
+    - name: Install musl tools
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y musl-tools
+      
+    - name: Install cross
+      if: matrix.use_cross
+      run: cargo install cross --git https://github.com/cross-rs/cross
+      
+    - name: Build binary (native)
+      if: ${{ !matrix.use_cross }}
+      run: cargo build --release --target ${{ matrix.target }}
+      
+    - name: Build binary (cross)
+      if: matrix.use_cross
+      run: cross build --release --target ${{ matrix.target }}
+      
+    - name: Prepare binary
+      run: |
+        BINARY_NAME="crates-docs-${{ matrix.arch }}"
+        cp target/${{ matrix.target }}/release/crates-docs "$BINARY_NAME"
+        chmod +x "$BINARY_NAME"
+        echo "binary_name=$BINARY_NAME" >> $GITHUB_OUTPUT
+      id: prepare
+      
+    - name: Upload binary artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: binary-${{ matrix.arch }}
+        path: ${{ steps.prepare.outputs.binary_name }}
+        retention-days: 1
+
   # Docker 镜像发布 - 只在推送版本标签时运行
   publish-docker:
     name: Publish Docker Images
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [check, test, build-windows, docs, docker]
+    needs: [build-docker-binaries]
     
     permissions:
       contents: read
@@ -394,10 +462,23 @@ jobs:
         echo "version=$VERSION" >> $GITHUB_OUTPUT
         echo "Tag version: $VERSION"
         
+    - name: Download amd64 binary
+      uses: actions/download-artifact@v4
+      with:
+        name: binary-amd64
+        path: ./binaries
+      
+    - name: Download arm64 binary
+      uses: actions/download-artifact@v4
+      with:
+        name: binary-arm64
+        path: ./binaries
+      
     - name: Build and push Docker image
       uses: docker/build-push-action@v7
       with:
         context: .
+        file: ./Dockerfile.release
         push: true
         platforms: linux/amd64,linux/arm64
         tags: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,7 +456,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crates-docs"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crates-docs"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "高性能 Rust crate 文档查询 MCP 服务器，支持 Stdio/HTTP/SSE 传输和 OAuth 认证"
 authors = ["KingingWang <KingingWang@foxmail.com>"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,41 @@
+# Dockerfile for release builds - uses pre-compiled binaries
+# This Dockerfile is optimized for CI/CD pipelines where binaries are pre-compiled
+# using cross-rs for cross-platform builds, avoiding slow QEMU emulation.
+#
+# Uses scratch (empty) base image since musl binary is fully statically linked.
+# CA certificates are copied from alpine for HTTPS support.
+
+# Stage 1: Get CA certificates from alpine
+FROM alpine:latest AS certs
+RUN apk add --no-cache ca-certificates
+
+# Stage 2: Final minimal image
+ARG TARGETARCH
+FROM scratch
+
+# Copy CA certificates for HTTPS requests to docs.rs and crates.io
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+# Copy pre-compiled binary based on target architecture
+# The binary is expected to be at ./binaries/crates-docs-${TARGETARCH}
+COPY binaries/crates-docs-${TARGETARCH} /app/crates-docs
+
+# Copy default configuration
+COPY examples/config.example.toml /app/config.toml
+
+# Set working directory
+WORKDIR /app
+
+# Expose port
+EXPOSE 8080
+
+# Set environment variables
+ENV RUST_LOG=info
+ENV CRATES_DOCS_HOST=0.0.0.0
+ENV CRATES_DOCS_PORT=8080
+ENV CRATES_DOCS_TRANSPORT_MODE=hybrid
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+
+# Start command (no shell needed for scratch image)
+ENTRYPOINT ["/app/crates-docs"]
+CMD ["serve", "--config", "/app/config.toml"]


### PR DESCRIPTION
- Add build-docker-binaries job for x86_64 and aarch64 musl targets
- Use cross-rs for efficient cross-compilation instead of QEMU
- Update publish-docker to use pre-built binaries
- Add Dockerfile.release for optimized Docker builds
- Bump version to 0.5.1