### PR TITLE
feat(release): bump version to 0.5.2 and fix Docker multi-arch build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -466,13 +466,31 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: binary-amd64
-        path: ./binaries
+        path: ./binaries/amd64
       
     - name: Download arm64 binary
       uses: actions/download-artifact@v4
       with:
         name: binary-arm64
-        path: ./binaries
+        path: ./binaries/arm64
+      
+    - name: Verify and prepare binaries
+      run: |
+        echo "Downloaded binaries structure:"
+        find ./binaries -type f -ls
+        
+        # Move binaries to expected locations for Docker
+        # download-artifact@v4 creates subdirectories with artifact names
+        mv ./binaries/amd64/crates-docs-amd64 ./binaries/crates-docs-amd64 || true
+        mv ./binaries/arm64/crates-docs-arm64 ./binaries/crates-docs-arm64 || true
+        
+        echo "Final binaries:"
+        ls -la ./binaries/
+        
+        # Verify files exist and are executable
+        test -f ./binaries/crates-docs-amd64 || { echo "ERROR: amd64 binary not found"; exit 1; }
+        test -f ./binaries/crates-docs-arm64 || { echo "ERROR: arm64 binary not found"; exit 1; }
+        chmod +x ./binaries/crates-docs-amd64 ./binaries/crates-docs-arm64
       
     - name: Build and push Docker image
       uses: docker/build-push-action@v7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,7 +456,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crates-docs"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crates-docs"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 description = "高性能 Rust crate 文档查询 MCP 服务器，支持 Stdio/HTTP/SSE 传输和 OAuth 认证"
 authors = ["KingingWang <KingingWang@foxmail.com>"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -10,14 +10,18 @@ FROM alpine:latest AS certs
 RUN apk add --no-cache ca-certificates
 
 # Stage 2: Final minimal image
-ARG TARGETARCH
 FROM scratch
+
+# ARG must be declared after FROM in multi-stage builds
+ARG TARGETARCH
+ARG TARGETVARIANT
 
 # Copy CA certificates for HTTPS requests to docs.rs and crates.io
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 # Copy pre-compiled binary based on target architecture
 # The binary is expected to be at ./binaries/crates-docs-${TARGETARCH}
+# TARGETARCH values: amd64, arm64 (set automatically by docker buildx)
 COPY binaries/crates-docs-${TARGETARCH} /app/crates-docs
 
 # Copy default configuration


### PR DESCRIPTION
- Update Cargo.toml and Cargo.lock version to 0.5.2
- Fix ARG declaration order in Dockerfile.release for multi-stage builds
- Add TARGETVARIANT ARG for proper multi-architecture support
- Improve CI workflow to handle binary downloads with subdirectories
- Add verification step to ensure binaries are correctly downloaded