### PR TITLE
feat(http): add automatic retry support to HTTP client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,6 +468,8 @@ dependencies = [
  "redis",
  "regex",
  "reqwest 0.13.2",
+ "reqwest-middleware",
+ "reqwest-retry",
  "rust-mcp-extra",
  "rust-mcp-macros",
  "rust-mcp-schema",
@@ -2255,6 +2257,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest-middleware"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "199dda04a536b532d0cc04d7979e39b1c763ea749bf91507017069c00b96056f"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest 0.13.2",
+ "thiserror 2.0.18",
+ "tower-service",
+]
+
+[[package]]
+name = "reqwest-retry"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe2412db2af7d2268e7a5406be0431f37d9eb67ff390f35b395716f5f06c2eaa"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "getrandom 0.2.17",
+ "http",
+ "hyper",
+ "reqwest 0.13.2",
+ "reqwest-middleware",
+ "retry-policies",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "wasmtimer",
+]
+
+[[package]]
+name = "retry-policies"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a4bd6027df676bcb752d3724db0ea3c0c5fc1dd0376fec51ac7dcaf9cc69be"
+dependencies = [
+ "rand 0.9.2",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3506,6 +3552,20 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "wasmtimer"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ rust-mcp-extra = { version = "0.2.3", optional = true }
 
 # HTTP 客户端
 reqwest = { version = "0.13", features = ["json"] }
+reqwest-middleware = "0.5"
+reqwest-retry = "0.9"
 tokio = { version = "1.50", features = ["full"] }
 
 # 序列化和配置
@@ -74,7 +76,7 @@ clap = { version = "4.5", features = ["derive", "env"] }
 chrono = "0.4"
 
 [dev-dependencies]
-tokio = { version = "1.40", features = ["full", "test-util"] }
+tokio = { version = "1.50", features = ["full", "test-util"] }
 reqwest = { version = "0.13", features = ["json"] }
 serde_json = "1.0"
 tempfile = "3.27.0"

--- a/src/tools/docs/mod.rs
+++ b/src/tools/docs/mod.rs
@@ -33,15 +33,15 @@ use std::sync::Arc;
 
 /// 文档服务
 ///
-/// 提供 HTTP 客户端、缓存和文档缓存的集中管理。
+/// 提供 HTTP 客户端（带自动重试）、缓存和文档缓存的集中管理。
 ///
 /// # 字段
 ///
-/// - `client`: HTTP 客户端
+/// - `client`: 带重试中间件的 HTTP 客户端
 /// - `cache`: 通用缓存实例
 /// - `doc_cache`: 文档专用缓存
 pub struct DocService {
-    client: reqwest::Client,
+    client: reqwest_middleware::ClientWithMiddleware,
     cache: Arc<dyn Cache>,
     doc_cache: cache::DocCache,
 }
@@ -94,7 +94,7 @@ impl DocService {
             .map_err(|e| {
                 crate::error::Error::initialization(
                     "http_client",
-                    format!("Failed to create HTTP client: {e}"),
+                    format!("Failed to create HTTP client with retry: {e}"),
                 )
             })?;
         Ok(Self {
@@ -127,7 +127,7 @@ impl DocService {
             .map_err(|e| {
                 crate::error::Error::initialization(
                     "http_client",
-                    format!("Failed to create HTTP client: {e}"),
+                    format!("Failed to create HTTP client with retry: {e}"),
                 )
             })?;
         Ok(Self {
@@ -137,9 +137,9 @@ impl DocService {
         })
     }
 
-    /// 获取 HTTP 客户端
+    /// 获取 HTTP 客户端（带重试中间件）
     #[must_use]
-    pub fn client(&self) -> &reqwest::Client {
+    pub fn client(&self) -> &reqwest_middleware::ClientWithMiddleware {
         &self.client
     }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,11 +2,16 @@
 
 use crate::error::{Error, Result};
 use reqwest::Client;
+use reqwest_middleware::ClientBuilder;
+use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Semaphore;
 
 /// HTTP client builder with retry support
+///
+/// This builder creates a `reqwest_middleware::ClientWithMiddleware` that includes
+/// automatic retry functionality for transient failures.
 pub struct HttpClientBuilder {
     timeout: Duration,
     connect_timeout: Duration,
@@ -123,8 +128,16 @@ impl HttpClientBuilder {
         self
     }
 
-    /// Build HTTP client
-    pub fn build(self) -> Result<Client> {
+    /// Build HTTP client with middleware chain
+    ///
+    /// This method builds a `reqwest_middleware::ClientWithMiddleware` that includes
+    /// automatic retry functionality using exponential backoff for transient failures.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `ClientWithMiddleware` that can be used like a regular `reqwest::Client`
+    /// but with automatic retry on transient errors.
+    pub fn build(self) -> Result<reqwest_middleware::ClientWithMiddleware> {
         let mut builder = Client::builder()
             .timeout(self.timeout)
             .connect_timeout(self.connect_timeout)
@@ -142,24 +155,52 @@ impl HttpClientBuilder {
             builder = builder.no_brotli();
         }
 
+        let client = builder
+            .build()
+            .map_err(|e| Error::http_request("BUILD", "client", 0, e.to_string()))?;
+
+        // Create retry policy with exponential backoff
+        let retry_policy = ExponentialBackoff::builder()
+            .retry_bounds(self.retry_initial_delay, self.retry_max_delay)
+            .build_with_max_retries(self.max_retries);
+
+        // Build client with retry middleware
+        Ok(ClientBuilder::new(client)
+            .with(RetryTransientMiddleware::new_with_policy(retry_policy))
+            .build())
+    }
+
+    /// Build HTTP client without retry support
+    ///
+    /// This method returns a plain `reqwest::Client` without any middleware.
+    /// Use [`build`](Self::build) for retry support.
+    pub fn build_plain(self) -> Result<Client> {
+        let mut builder = Client::builder()
+            .timeout(self.timeout)
+            .connect_timeout(self.connect_timeout)
+            .pool_max_idle_per_host(self.pool_max_idle_per_host)
+            .pool_idle_timeout(self.pool_idle_timeout)
+            .user_agent(&self.user_agent);
+
+        if !self.enable_gzip {
+            builder = builder.no_gzip();
+        }
+
+        if !self.enable_brotli {
+            builder = builder.no_brotli();
+        }
+
         builder
             .build()
             .map_err(|e| Error::http_request("BUILD", "client", 0, e.to_string()))
     }
-
-    /// Build HTTP client with retry support
-    ///
-    /// Note: Retry logic is implemented at the application level for better control.
-    /// This method returns the standard `reqwest::Client`.
-    pub fn build_with_retry(self) -> Result<Client> {
-        // Build client with configured settings
-        // Retry logic should be implemented at the application level
-        // for better control over retry behavior
-        self.build()
-    }
 }
 
-/// Create HTTP client from performance config
+/// Create HTTP client builder from performance config
+///
+/// This function creates an `HttpClientBuilder` pre-configured with settings
+/// from the provided `PerformanceConfig`. The resulting client will include
+/// automatic retry functionality.
 #[must_use]
 pub fn create_http_client_from_config(
     config: &crate::config::PerformanceConfig,


### PR DESCRIPTION
Add reqwest-middleware and reqwest-retry dependencies to enable automatic retry functionality for transient failures with exponential backoff.