### PR TITLE
refactor: remove deprecated init_logging, improve panic messages, add…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,35 +69,6 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 /// Server name
 pub const NAME: &str = "crates-docs";
 
-/// Initialize the logging system (simple version using boolean parameter)
-///
-/// # Errors
-/// Returns an error if logging system initialization fails
-#[deprecated(note = "Please use init_logging_with_config instead")]
-pub fn init_logging(debug: bool) -> Result<()> {
-    use tracing_subscriber::{fmt, prelude::*, EnvFilter};
-
-    let filter = if debug {
-        EnvFilter::new("debug")
-    } else {
-        EnvFilter::new("info")
-    };
-
-    let fmt_layer = fmt::layer()
-        .with_target(true)
-        .with_thread_ids(true)
-        .with_thread_names(true)
-        .compact();
-
-    tracing_subscriber::registry()
-        .with(filter)
-        .with(fmt_layer)
-        .try_init()
-        .map_err(|e| error::Error::initialization("logging", e.to_string()))?;
-
-    Ok(())
-}
-
 /// Initialize logging system with configuration
 ///
 /// # Errors

--- a/src/tools/docs/html.rs
+++ b/src/tools/docs/html.rs
@@ -20,29 +20,33 @@ const NAV_TAGS: &[&str] = &["nav", "header", "footer", "aside"];
 const UI_TAGS: &[&str] = &["button", "summary"];
 
 /// Regex patterns for self-closing/void tags to remove
-static LINK_TAG_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"<link[^>]*>").unwrap());
+static LINK_TAG_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"<link[^>]*>").expect("hardcoded valid regex pattern"));
 
-static META_TAG_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"<meta[^>]*>").unwrap());
+static META_TAG_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"<meta[^>]*>").expect("hardcoded valid regex pattern"));
 
 /// Regex to remove "Copy item path" and similar UI text
-static COPY_PATH_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"Copy item path").unwrap());
+static COPY_PATH_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"Copy item path").expect("hardcoded valid regex pattern"));
 
 /// Regex to remove anchor links like [§](#xxx)
 static ANCHOR_LINK_REGEX: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"\[§\]\([^)]*\)").unwrap());
+    LazyLock::new(|| Regex::new(r"\[§\]\([^)]*\)").expect("hardcoded valid regex pattern"));
 
 /// Regex to remove relative source links like [Source](../src/...)
 static SOURCE_LINK_REGEX: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"\[Source\]\([^)]*\)").unwrap());
+    LazyLock::new(|| Regex::new(r"\[Source\]\([^)]*\)").expect("hardcoded valid regex pattern"));
 
 /// Regex to remove relative documentation links like [de](de/index.html) or [forward\_to\_deserialize\_any](macro.xxx.html)
 /// Matches: [text](relative_path.html) where `relative_path` starts with letter and ends with .html
-static RELATIVE_LINK_REGEX: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"\[[^\]]*\]\([a-zA-Z][^)]*\.html\)").unwrap());
+static RELATIVE_LINK_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\[[^\]]*\]\([a-zA-Z][^)]*\.html\)").expect("hardcoded valid regex pattern")
+});
 
 /// Regex to clean up section markers like [§](#xxx) that may remain in headings
 static SECTION_MARKER_REGEX: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"\[§\]\([^)]*\)").unwrap());
+    LazyLock::new(|| Regex::new(r"\[§\]\([^)]*\)").expect("hardcoded valid regex pattern"));
 
 /// Clean HTML by removing unwanted tags and their content
 ///

--- a/src/tools/docs/search.rs
+++ b/src/tools/docs/search.rs
@@ -214,6 +214,7 @@ fn format_search_results(crates: &[CrateInfo], format: &str) -> String {
 }
 
 fn format_markdown_results(crates: &[CrateInfo]) -> String {
+    // SAFETY: writeln! to String never fails (writes to memory buffer). unwrap() is safe here.
     use std::fmt::Write;
     let estimated_size = crates.len() * 200 + 20;
     let mut output = String::with_capacity(estimated_size);
@@ -248,6 +249,7 @@ fn format_markdown_results(crates: &[CrateInfo]) -> String {
 }
 
 fn format_text_results(crates: &[CrateInfo]) -> String {
+    // SAFETY: writeln! to String never fails (writes to memory buffer). unwrap() is safe here.
     use std::fmt::Write;
     let estimated_size = crates.len() * 100;
     let mut output = String::with_capacity(estimated_size);

--- a/src/tools/health.rs
+++ b/src/tools/health.rs
@@ -236,6 +236,7 @@ impl Tool for HealthCheckToolImpl {
         let health_status = self.perform_checks(&check_type, verbose).await;
 
         let content = if verbose {
+            // SAFETY: write! to String never fails (writes to memory buffer). unwrap() is safe here.
             serde_json::to_string_pretty(&health_status).map_err(|e| {
                 rust_mcp_sdk::schema::CallToolError::from_message(format!(
                     "JSON serialization failed: {e}"


### PR DESCRIPTION
… SAFETY docs

- Remove deprecated init_logging(debug: bool) from lib.rs
- Change unwrap() to expect() for static regex patterns in html.rs
- Add SAFETY comments for writeln!/write! unwrap calls