### PR TITLE
refactor: extract common fetch_html, remove dead code, fix security d…

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -495,11 +495,11 @@ impl AppConfig {
         }
 
         if let Ok(enable_console) = std::env::var("CRATES_DOCS_ENABLE_CONSOLE") {
-            config.logging.enable_console = enable_console.parse().unwrap_or(true);
+            config.logging.enable_console = enable_console.parse().unwrap_or(false);
         }
 
         if let Ok(enable_file) = std::env::var("CRATES_DOCS_ENABLE_FILE") {
-            config.logging.enable_file = enable_file.parse().unwrap_or(true);
+            config.logging.enable_file = enable_file.parse().unwrap_or(false);
         }
 
         #[cfg(feature = "api-key")]

--- a/src/tools/docs/html.rs
+++ b/src/tools/docs/html.rs
@@ -174,57 +174,6 @@ fn extract_text_excluding_skip_tags(
     }
 }
 
-#[inline]
-#[allow(dead_code)]
-fn is_block_element(tag: &str) -> bool {
-    const BLOCK_ELEMENTS: &[&str] = &[
-        "address",
-        "article",
-        "aside",
-        "blockquote",
-        "body",
-        "canvas",
-        "dd",
-        "div",
-        "dl",
-        "dt",
-        "fieldset",
-        "figcaption",
-        "figure",
-        "footer",
-        "form",
-        "h1",
-        "h2",
-        "h3",
-        "h4",
-        "h5",
-        "h6",
-        "head",
-        "header",
-        "hgroup",
-        "hr",
-        "html",
-        "li",
-        "main",
-        "nav",
-        "noscript",
-        "ol",
-        "p",
-        "pre",
-        "section",
-        "table",
-        "tbody",
-        "td",
-        "tfoot",
-        "th",
-        "thead",
-        "tr",
-        "ul",
-        "video",
-    ];
-    BLOCK_ELEMENTS.contains(&tag)
-}
-
 /// Extract documentation from HTML by cleaning and converting to Markdown
 ///
 /// For docs.rs pages, extracts only the main content area to avoid
@@ -340,7 +289,9 @@ mod tests {
 
     #[test]
     fn test_clean_whitespace() {
-        assert_eq!(clean_whitespace("  hello   world  "), "hello world");
+        assert_eq!(clean_whitespace(" hello world "), "hello world");
+        // Multi-space boundary test
+        assert_eq!(clean_whitespace("  hello    world  "), "hello world");
         assert_eq!(clean_whitespace("\t\nhello\n\tworld\t\n"), "hello world");
     }
 

--- a/src/tools/docs/lookup_crate.rs
+++ b/src/tools/docs/lookup_crate.rs
@@ -9,6 +9,8 @@ use rust_mcp_sdk::schema::CallToolError;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
+const TOOL_NAME: &str = "lookup_crate";
+
 /// Lookup crate documentation tool
 #[rust_mcp_sdk::macros::mcp_tool(
     name = "lookup_crate",
@@ -70,38 +72,6 @@ impl LookupCrateToolImpl {
         }
     }
 
-    /// Fetch HTML from docs.rs
-    async fn fetch_html(&self, url: &str) -> std::result::Result<String, CallToolError> {
-        let response = self
-            .service
-            .client()
-            .get(url)
-            .send()
-            .await
-            .map_err(|e| CallToolError::from_message(format!("HTTP request failed: {e}")))?;
-
-        let status = response.status();
-        if !status.is_success() {
-            let error_body = response.text().await.map_err(|e| {
-                CallToolError::from_message(format!("Failed to read error response: {e}"))
-            })?;
-            return Err(CallToolError::from_message(format!(
-                "Failed to get documentation: HTTP {} - {}",
-                status,
-                if error_body.is_empty() {
-                    "No error details".to_string()
-                } else {
-                    error_body
-                }
-            )));
-        }
-
-        response
-            .text()
-            .await
-            .map_err(|e| CallToolError::from_message(format!("Failed to read response: {e}")))
-    }
-
     /// Get crate documentation (markdown format)
     async fn fetch_crate_docs(
         &self,
@@ -120,7 +90,7 @@ impl LookupCrateToolImpl {
 
         // Fetch from docs.rs
         let url = Self::build_url(crate_name, version);
-        let html = self.fetch_html(&url).await?;
+        let html = self.service.fetch_html(&url, Some(TOOL_NAME)).await?;
 
         // Extract documentation
         let docs = html::extract_documentation(&html);
@@ -130,7 +100,9 @@ impl LookupCrateToolImpl {
             .doc_cache()
             .set_crate_docs(crate_name, version, docs.clone())
             .await
-            .map_err(|e| CallToolError::from_message(format!("Cache set failed: {e}")))?;
+            .map_err(|e| {
+                CallToolError::from_message(format!("[{TOOL_NAME}] Cache set failed: {e}"))
+            })?;
 
         Ok(docs)
     }
@@ -142,7 +114,7 @@ impl LookupCrateToolImpl {
         version: Option<&str>,
     ) -> std::result::Result<String, CallToolError> {
         let url = Self::build_url(crate_name, version);
-        let html = self.fetch_html(&url).await?;
+        let html = self.service.fetch_html(&url, Some(TOOL_NAME)).await?;
         Ok(html::html_to_text(&html))
     }
 
@@ -153,7 +125,7 @@ impl LookupCrateToolImpl {
         version: Option<&str>,
     ) -> std::result::Result<String, CallToolError> {
         let url = Self::build_url(crate_name, version);
-        self.fetch_html(&url).await
+        self.service.fetch_html(&url, Some(TOOL_NAME)).await
     }
 }
 

--- a/src/tools/docs/lookup_item.rs
+++ b/src/tools/docs/lookup_item.rs
@@ -9,6 +9,8 @@ use rust_mcp_sdk::schema::CallToolError;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
+const TOOL_NAME: &str = "lookup_item";
+
 /// Lookup item documentation tool
 #[rust_mcp_sdk::macros::mcp_tool(
     name = "lookup_item",
@@ -78,38 +80,6 @@ impl LookupItemToolImpl {
         }
     }
 
-    /// Fetch HTML from docs.rs
-    async fn fetch_html(&self, url: &str) -> std::result::Result<String, CallToolError> {
-        let response = self
-            .service
-            .client()
-            .get(url)
-            .send()
-            .await
-            .map_err(|e| CallToolError::from_message(format!("HTTP request failed: {e}")))?;
-
-        let status = response.status();
-        if !status.is_success() {
-            let error_body = response.text().await.map_err(|e| {
-                CallToolError::from_message(format!("Failed to read error response: {e}"))
-            })?;
-            return Err(CallToolError::from_message(format!(
-                "Failed to get item documentation: HTTP {} - {}",
-                status,
-                if error_body.is_empty() {
-                    "No error details".to_string()
-                } else {
-                    error_body
-                }
-            )));
-        }
-
-        response
-            .text()
-            .await
-            .map_err(|e| CallToolError::from_message(format!("Failed to read response: {e}")))
-    }
-
     /// Get item documentation (markdown format)
     async fn fetch_item_docs(
         &self,
@@ -129,7 +99,7 @@ impl LookupItemToolImpl {
 
         // Fetch from docs.rs
         let url = Self::build_search_url(crate_name, item_path, version);
-        let html = self.fetch_html(&url).await?;
+        let html = self.service.fetch_html(&url, Some(TOOL_NAME)).await?;
 
         // Extract search results
         let docs = html::extract_search_results(&html, item_path);
@@ -139,7 +109,9 @@ impl LookupItemToolImpl {
             .doc_cache()
             .set_item_docs(crate_name, item_path, version, docs.clone())
             .await
-            .map_err(|e| CallToolError::from_message(format!("Cache set failed: {e}")))?;
+            .map_err(|e| {
+                CallToolError::from_message(format!("[{TOOL_NAME}] Cache set failed: {e}"))
+            })?;
 
         Ok(docs)
     }
@@ -152,7 +124,7 @@ impl LookupItemToolImpl {
         version: Option<&str>,
     ) -> std::result::Result<String, CallToolError> {
         let url = Self::build_search_url(crate_name, item_path, version);
-        let html = self.fetch_html(&url).await?;
+        let html = self.service.fetch_html(&url, Some(TOOL_NAME)).await?;
         Ok(format!(
             "Search results: {}\n\n{}",
             item_path,
@@ -168,7 +140,7 @@ impl LookupItemToolImpl {
         version: Option<&str>,
     ) -> std::result::Result<String, CallToolError> {
         let url = Self::build_search_url(crate_name, item_path, version);
-        self.fetch_html(&url).await
+        self.service.fetch_html(&url, Some(TOOL_NAME)).await
     }
 }
 

--- a/src/tools/docs/mod.rs
+++ b/src/tools/docs/mod.rs
@@ -29,6 +29,7 @@ pub mod search;
 
 use crate::cache::{Cache, CacheConfig};
 use crate::config::PerformanceConfig;
+use rust_mcp_sdk::schema::CallToolError;
 use std::sync::Arc;
 
 /// Document service
@@ -157,6 +158,56 @@ impl DocService {
     pub fn doc_cache(&self) -> &cache::DocCache {
         &self.doc_cache
     }
+
+    /// Fetch HTML content from a URL
+    ///
+    /// This is a shared utility method used by multiple tools to fetch HTML
+    /// from docs.rs and crates.io.
+    ///
+    /// # Arguments
+    ///
+    /// * `url` - The URL to fetch
+    /// * `tool_name` - Optional tool name for better error messages (e.g., "`lookup_crate`", "`lookup_item`")
+    ///
+    /// # Errors
+    ///
+    /// Returns a `CallToolError` if:
+    /// - The HTTP request fails
+    /// - The response status is not successful
+    /// - Reading the response body fails
+    pub async fn fetch_html(
+        &self,
+        url: &str,
+        tool_name: Option<&str>,
+    ) -> Result<String, CallToolError> {
+        let response = self.client.get(url).send().await.map_err(|e| {
+            let prefix = tool_name.map_or(String::new(), |n| format!("[{n}] "));
+            CallToolError::from_message(format!("{prefix}HTTP request failed: {e}"))
+        })?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let error_body = response.text().await.map_err(|e| {
+                let prefix = tool_name.map_or(String::new(), |n| format!("[{n}] "));
+                CallToolError::from_message(format!("{prefix}Failed to read error response: {e}"))
+            })?;
+            let prefix = tool_name.map_or(String::new(), |n| format!("[{n}] "));
+            return Err(CallToolError::from_message(format!(
+                "{prefix}Failed to get documentation: HTTP {} - {}",
+                status,
+                if error_body.is_empty() {
+                    "No error details"
+                } else {
+                    &error_body
+                }
+            )));
+        }
+
+        response.text().await.map_err(|e| {
+            let prefix = tool_name.map_or(String::new(), |n| format!("[{n}] "));
+            CallToolError::from_message(format!("{prefix}Failed to read response: {e}"))
+        })
+    }
 }
 
 impl Default for DocService {
@@ -173,3 +224,24 @@ pub use search::SearchCratesTool;
 
 /// Re-export cache types
 pub use cache::DocCacheTtl;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_doc_service_default() {
+        let service = DocService::default();
+        let _ = service.client();
+        // HTTP client is always available after service creation
+    }
+
+    #[test]
+    fn test_doc_service_accessors() {
+        let service = DocService::default();
+        let _ = service.client();
+        let _ = service.client();
+        let _ = service.cache();
+        let _ = service.doc_cache();
+    }
+}

--- a/src/tools/docs/search.rs
+++ b/src/tools/docs/search.rs
@@ -68,6 +68,9 @@ const VALID_SEARCH_SORTS: &[&str] = &[
     "new",
 ];
 
+/// Default output format for search results
+const DEFAULT_FORMAT: &str = "markdown";
+
 pub struct SearchCratesToolImpl {
     service: Arc<super::DocService>,
 }
@@ -294,8 +297,8 @@ impl Tool for SearchCratesToolImpl {
         let sort = normalize_search_sort(params.sort.as_deref())?;
         let crates = self.search_crates(&params.query, limit, &sort).await?;
 
-        let format = params.format.unwrap_or_else(|| "markdown".to_string());
-        let content = format_search_results(&crates, &format);
+        let format = params.format.as_deref().unwrap_or(DEFAULT_FORMAT);
+        let content = format_search_results(&crates, format);
 
         Ok(rust_mcp_sdk::schema::CallToolResult::text_content(vec![
             content.into(),


### PR DESCRIPTION
…efaults

- Extract shared fetch_html method into DocService to eliminate code duplication between lookup_crate and lookup_item tools
- Add tool_name parameter to fetch_html for better error message debugging
- Remove unused is_block_element function from html.rs
- Add DEFAULT_FORMAT constant in search.rs for better maintainability
- Fix security issue: boolean env var parsing now defaults to false on parse failure instead of true (fail-safe approach)
- Add unit tests for DocService
- Restore multi-space boundary test in test_clean_whitespace