### PR TITLE
perf: reuse docs lookups across output formats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,6 +566,7 @@ dependencies = [
  "fastrand",
  "flate2",
  "html2md",
+ "http",
  "moka",
  "notify",
  "prometheus-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ tempfile = "3.27.0"
 temp-env = "0.3"
 wiremock = "0.6"
 serial_test = "3.0"
+http = "1"
 
 [[bin]]
 name = "crates-docs"

--- a/src/tools/docs/cache/key.rs
+++ b/src/tools/docs/cache/key.rs
@@ -36,6 +36,18 @@ fn is_valid_item_path(path: &str) -> bool {
 pub struct CacheKeyGenerator;
 
 impl CacheKeyGenerator {
+    /// Build a raw crate HTML cache key with normalization.
+    ///
+    /// This key stores the fetched docs.rs HTML artifact shared across
+    /// markdown, text, and html responses for the same crate lookup.
+    ///
+    /// Key format: `crate:{name}:html` or `crate:{name}:{version}:html`
+    #[must_use]
+    pub fn crate_html_cache_key(crate_name: &str, version: Option<&str>) -> String {
+        let base_key = Self::crate_cache_key(crate_name, version);
+        format!("{base_key}:html")
+    }
+
     /// Build crate cache key with normalization
     ///
     /// # Normalization rules
@@ -107,6 +119,18 @@ impl CacheKeyGenerator {
             None => format!("item:{normalized_name}:{normalized_path}"),
         }
     }
+
+    /// Build a raw item HTML cache key with normalization.
+    ///
+    /// This key stores the fetched docs.rs search-result HTML artifact shared
+    /// across markdown, text, and html responses for the same item lookup.
+    ///
+    /// Key format: `item:{crate}:{path}:html` or `item:{crate}:{version}:{path}:html`
+    #[must_use]
+    pub fn item_html_cache_key(crate_name: &str, item_path: &str, version: Option<&str>) -> String {
+        let base_key = Self::item_cache_key(crate_name, item_path, version);
+        format!("{base_key}:html")
+    }
 }
 
 #[cfg(test)]
@@ -123,6 +147,10 @@ mod tests {
             CacheKeyGenerator::crate_cache_key("serde", Some("1.0")),
             "crate:serde:1.0"
         );
+        assert_eq!(
+            CacheKeyGenerator::crate_html_cache_key("serde", Some("1.0")),
+            "crate:serde:1.0:html"
+        );
 
         assert_eq!(
             CacheKeyGenerator::search_cache_key("web framework", 10),
@@ -136,6 +164,10 @@ mod tests {
         assert_eq!(
             CacheKeyGenerator::item_cache_key("serde", "Serialize", Some("1.0")),
             "item:serde:1.0:Serialize"
+        );
+        assert_eq!(
+            CacheKeyGenerator::item_html_cache_key("serde", "Serialize", Some("1.0")),
+            "item:serde:1.0:Serialize:html"
         );
     }
 

--- a/src/tools/docs/cache/mod.rs
+++ b/src/tools/docs/cache/mod.rs
@@ -150,6 +150,36 @@ impl DocCache {
         Ok(())
     }
 
+    /// Get cached crate HTML
+    pub async fn get_crate_html(&self, crate_name: &str, version: Option<&str>) -> Option<String> {
+        let key = CacheKeyGenerator::crate_html_cache_key(crate_name, version);
+        let result = self.cache.get(&key).await;
+        if result.is_some() {
+            self.stats.record_hit();
+        } else {
+            self.stats.record_miss();
+        }
+        result.map(|arc| (*arc).clone())
+    }
+
+    /// Set crate HTML cache
+    ///
+    /// # Errors
+    ///
+    /// Returns error if cache operation fails
+    pub async fn set_crate_html(
+        &self,
+        crate_name: &str,
+        version: Option<&str>,
+        content: String,
+    ) -> crate::error::Result<()> {
+        let key = CacheKeyGenerator::crate_html_cache_key(crate_name, version);
+        let ttl = self.ttl.crate_docs_duration();
+        self.cache.set(key, content, Some(ttl)).await?;
+        self.stats.record_set();
+        Ok(())
+    }
+
     /// Get cached search results
     ///
     /// # Arguments
@@ -244,6 +274,42 @@ impl DocCache {
         content: String,
     ) -> crate::error::Result<()> {
         let key = CacheKeyGenerator::item_cache_key(crate_name, item_path, version);
+        let ttl = self.ttl.item_docs_duration();
+        self.cache.set(key, content, Some(ttl)).await?;
+        self.stats.record_set();
+        Ok(())
+    }
+
+    /// Get cached item HTML
+    pub async fn get_item_html(
+        &self,
+        crate_name: &str,
+        item_path: &str,
+        version: Option<&str>,
+    ) -> Option<String> {
+        let key = CacheKeyGenerator::item_html_cache_key(crate_name, item_path, version);
+        let result = self.cache.get(&key).await;
+        if result.is_some() {
+            self.stats.record_hit();
+        } else {
+            self.stats.record_miss();
+        }
+        result.map(|arc| (*arc).clone())
+    }
+
+    /// Set item HTML cache
+    ///
+    /// # Errors
+    ///
+    /// Returns error if cache operation fails
+    pub async fn set_item_html(
+        &self,
+        crate_name: &str,
+        item_path: &str,
+        version: Option<&str>,
+        content: String,
+    ) -> crate::error::Result<()> {
+        let key = CacheKeyGenerator::item_html_cache_key(crate_name, item_path, version);
         let ttl = self.ttl.item_docs_duration();
         self.cache.set(key, content, Some(ttl)).await?;
         self.stats.record_set();

--- a/src/tools/docs/lookup_crate.rs
+++ b/src/tools/docs/lookup_crate.rs
@@ -87,6 +87,34 @@ impl LookupCrateToolImpl {
         super::build_docs_url(crate_name, version)
     }
 
+    async fn fetch_crate_html(
+        &self,
+        crate_name: &str,
+        version: Option<&str>,
+    ) -> std::result::Result<String, CallToolError> {
+        if let Some(cached) = self
+            .service
+            .doc_cache()
+            .get_crate_html(crate_name, version)
+            .await
+        {
+            return Ok(cached);
+        }
+
+        let url = Self::build_url(crate_name, version);
+        let html = self.service.fetch_html(&url, Some(TOOL_NAME)).await?;
+
+        self.service
+            .doc_cache()
+            .set_crate_html(crate_name, version, html.clone())
+            .await
+            .map_err(|e| {
+                CallToolError::from_message(format!("[{TOOL_NAME}] Cache set failed: {e}"))
+            })?;
+
+        Ok(html)
+    }
+
     /// Get crate documentation (markdown format)
     async fn fetch_crate_docs(
         &self,
@@ -103,9 +131,7 @@ impl LookupCrateToolImpl {
             return Ok(cached);
         }
 
-        // Fetch from docs.rs
-        let url = Self::build_url(crate_name, version);
-        let html = self.service.fetch_html(&url, Some(TOOL_NAME)).await?;
+        let html = self.fetch_crate_html(crate_name, version).await?;
 
         // Extract documentation
         let docs = html::extract_documentation(&html);
@@ -128,8 +154,7 @@ impl LookupCrateToolImpl {
         crate_name: &str,
         version: Option<&str>,
     ) -> std::result::Result<String, CallToolError> {
-        let url = Self::build_url(crate_name, version);
-        let html = self.service.fetch_html(&url, Some(TOOL_NAME)).await?;
+        let html = self.fetch_crate_html(crate_name, version).await?;
         Ok(html::html_to_text(&html))
     }
 
@@ -139,8 +164,7 @@ impl LookupCrateToolImpl {
         crate_name: &str,
         version: Option<&str>,
     ) -> std::result::Result<String, CallToolError> {
-        let url = Self::build_url(crate_name, version);
-        self.service.fetch_html(&url, Some(TOOL_NAME)).await
+        self.fetch_crate_html(crate_name, version).await
     }
 }
 

--- a/src/tools/docs/lookup_item.rs
+++ b/src/tools/docs/lookup_item.rs
@@ -90,6 +90,35 @@ impl LookupItemToolImpl {
         super::build_docs_item_url(crate_name, version, item_path)
     }
 
+    async fn fetch_item_html(
+        &self,
+        crate_name: &str,
+        item_path: &str,
+        version: Option<&str>,
+    ) -> std::result::Result<String, CallToolError> {
+        if let Some(cached) = self
+            .service
+            .doc_cache()
+            .get_item_html(crate_name, item_path, version)
+            .await
+        {
+            return Ok(cached);
+        }
+
+        let url = Self::build_search_url(crate_name, item_path, version);
+        let html = self.service.fetch_html(&url, Some(TOOL_NAME)).await?;
+
+        self.service
+            .doc_cache()
+            .set_item_html(crate_name, item_path, version, html.clone())
+            .await
+            .map_err(|e| {
+                CallToolError::from_message(format!("[{TOOL_NAME}] Cache set failed: {e}"))
+            })?;
+
+        Ok(html)
+    }
+
     /// Get item documentation (markdown format)
     async fn fetch_item_docs(
         &self,
@@ -107,9 +136,7 @@ impl LookupItemToolImpl {
             return Ok(cached);
         }
 
-        // Fetch from docs.rs
-        let url = Self::build_search_url(crate_name, item_path, version);
-        let html = self.service.fetch_html(&url, Some(TOOL_NAME)).await?;
+        let html = self.fetch_item_html(crate_name, item_path, version).await?;
 
         // Extract search results
         let docs = html::extract_search_results(&html, item_path);
@@ -133,8 +160,7 @@ impl LookupItemToolImpl {
         item_path: &str,
         version: Option<&str>,
     ) -> std::result::Result<String, CallToolError> {
-        let url = Self::build_search_url(crate_name, item_path, version);
-        let html = self.service.fetch_html(&url, Some(TOOL_NAME)).await?;
+        let html = self.fetch_item_html(crate_name, item_path, version).await?;
         Ok(format!(
             "Search results: {}\n\n{}",
             item_path,
@@ -149,8 +175,7 @@ impl LookupItemToolImpl {
         item_path: &str,
         version: Option<&str>,
     ) -> std::result::Result<String, CallToolError> {
-        let url = Self::build_search_url(crate_name, item_path, version);
-        self.service.fetch_html(&url, Some(TOOL_NAME)).await
+        self.fetch_item_html(crate_name, item_path, version).await
     }
 }
 

--- a/tests/unit/tools_docs_tests.rs
+++ b/tests/unit/tools_docs_tests.rs
@@ -4,8 +4,14 @@ use crates_docs::tools::docs::{
     cache::{DocCache, DocCacheTtl},
     html::{clean_html, extract_documentation, extract_search_results, html_to_text},
 };
+use http::Extensions;
+use reqwest::{Request, Response, Url};
+use reqwest_middleware::{ClientBuilder, Middleware, Next};
 use serial_test::serial;
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
 
 struct EnvVarGuard {
     key: &'static str,
@@ -31,6 +37,52 @@ impl Drop for EnvVarGuard {
             std::env::remove_var(self.key);
         }
     }
+}
+
+#[derive(Clone)]
+/// Test middleware that redirects outgoing docs.rs requests to a wiremock
+/// server while keeping the original request path and query intact.
+struct RewriteDocsRsMiddleware {
+    target_base_url: Url,
+    request_count: Arc<AtomicUsize>,
+}
+
+#[async_trait::async_trait]
+impl Middleware for RewriteDocsRsMiddleware {
+    async fn handle(
+        &self,
+        mut req: Request,
+        extensions: &mut Extensions,
+        next: Next<'_>,
+    ) -> reqwest_middleware::Result<Response> {
+        self.request_count.fetch_add(1, Ordering::SeqCst);
+
+        let url = req.url_mut();
+        url.set_scheme(self.target_base_url.scheme())
+            .expect("scheme rewrite should succeed");
+        url.set_host(self.target_base_url.host_str())
+            .expect("host rewrite should succeed");
+        url.set_port(self.target_base_url.port())
+            .expect("port rewrite should succeed");
+
+        next.run(req, extensions).await
+    }
+}
+
+fn build_docs_rs_test_client(
+    target_base_url: &str,
+    request_count: Arc<AtomicUsize>,
+) -> Arc<reqwest_middleware::ClientWithMiddleware> {
+    let middleware = RewriteDocsRsMiddleware {
+        target_base_url: Url::parse(target_base_url).expect("mock server URL should parse"),
+        request_count,
+    };
+
+    Arc::new(
+        ClientBuilder::new(reqwest::Client::new())
+            .with(middleware)
+            .build(),
+    )
 }
 
 /// Test DocCacheTtl default values
@@ -424,6 +476,132 @@ async fn test_lookup_crate_tool_execute_with_version() {
 }
 
 #[tokio::test]
+#[serial(docs_rs_env)]
+async fn test_lookup_crate_tool_reuses_single_upstream_fetch_across_formats() {
+    use crates_docs::tools::Tool;
+    use wiremock::{matchers, Mock, MockServer, ResponseTemplate};
+
+    let mock_server = MockServer::start().await;
+    let mock_uri = mock_server.uri();
+    let mock_html = r#"
+    <!DOCTYPE html>
+    <html>
+    <body>
+        <section id="main-content">
+            <h1>Serde</h1>
+            <p>Serialization framework for Rust</p>
+        </section>
+    </body>
+    </html>
+    "#;
+
+    Mock::given(matchers::method("GET"))
+        .and(matchers::path("/serde/"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(mock_html))
+        .mount(&mock_server)
+        .await;
+
+    let memory_cache = crates_docs::cache::memory::MemoryCache::new(100);
+    let cache = Arc::new(memory_cache);
+    let cache_config = crates_docs::cache::CacheConfig::default();
+    let request_count = Arc::new(AtomicUsize::new(0));
+
+    let service = crates_docs::tools::docs::DocService::with_custom_client(
+        cache,
+        &cache_config,
+        build_docs_rs_test_client(&mock_uri, request_count.clone()),
+    );
+
+    let tool = crates_docs::tools::docs::lookup_crate::LookupCrateToolImpl::new(Arc::new(service));
+
+    let markdown_args = serde_json::json!({
+        "crate_name": "serde",
+        "format": "markdown"
+    });
+    let text_args = serde_json::json!({
+        "crate_name": "serde",
+        "format": "text"
+    });
+
+    let markdown_result = tool.execute(markdown_args).await;
+    assert!(markdown_result.is_ok());
+
+    let text_result = tool.execute(text_args).await;
+    assert!(text_result.is_ok());
+
+    assert_eq!(
+        request_count.load(Ordering::SeqCst),
+        1,
+        "expected a single upstream request"
+    );
+}
+
+#[tokio::test]
+#[serial(docs_rs_env)]
+async fn test_lookup_crate_tool_keeps_versioned_and_unversioned_cache_entries_distinct() {
+    use crates_docs::tools::Tool;
+    use wiremock::{matchers, Mock, MockServer, ResponseTemplate};
+
+    let mock_server = MockServer::start().await;
+    let mock_uri = mock_server.uri();
+
+    Mock::given(matchers::method("GET"))
+        .and(matchers::path("/serde/"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_string(
+                r#"<html><body><section id="main-content"><h1>Serde latest</h1></section></body></html>"#,
+            ),
+        )
+        .mount(&mock_server)
+        .await;
+
+    Mock::given(matchers::method("GET"))
+        .and(matchers::path("/serde/1.0.0/"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_string(
+                r#"<html><body><section id="main-content"><h1>Serde 1.0.0</h1></section></body></html>"#,
+            ),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let memory_cache = crates_docs::cache::memory::MemoryCache::new(100);
+    let cache = Arc::new(memory_cache);
+    let cache_config = crates_docs::cache::CacheConfig::default();
+    let request_count = Arc::new(AtomicUsize::new(0));
+
+    let service = crates_docs::tools::docs::DocService::with_custom_client(
+        cache,
+        &cache_config,
+        build_docs_rs_test_client(&mock_uri, request_count.clone()),
+    );
+
+    let tool = crates_docs::tools::docs::lookup_crate::LookupCrateToolImpl::new(Arc::new(service));
+
+    let latest_args = serde_json::json!({
+        "crate_name": "serde",
+        "format": "markdown"
+    });
+    let versioned_args = serde_json::json!({
+        "crate_name": "serde",
+        "version": "1.0.0",
+        "format": "text"
+    });
+
+    let latest_result = tool.execute(latest_args).await;
+    assert!(latest_result.is_ok());
+
+    let versioned_result = tool.execute(versioned_args).await;
+    assert!(versioned_result.is_ok());
+
+    assert_eq!(
+        request_count.load(Ordering::SeqCst),
+        2,
+        "expected separate upstream requests"
+    );
+}
+
+#[tokio::test]
 async fn test_lookup_crate_tool_invalid_params() {
     use crates_docs::tools::Tool;
 
@@ -641,6 +819,134 @@ async fn test_lookup_item_tool_execute_with_version() {
 
     let result = tool.execute(args).await;
     assert!(result.is_ok());
+}
+
+#[tokio::test]
+#[serial(docs_rs_env)]
+async fn test_lookup_item_tool_reuses_single_upstream_fetch_across_formats() {
+    use crates_docs::tools::Tool;
+    use wiremock::{matchers, Mock, MockServer, ResponseTemplate};
+
+    let mock_server = MockServer::start().await;
+    let mock_uri = mock_server.uri();
+    let mock_html = r#"
+    <html>
+    <body>
+        <h1>Serialize Trait</h1>
+        <p>Serialize data structure</p>
+    </body>
+    </html>
+    "#;
+
+    Mock::given(matchers::method("GET"))
+        .and(matchers::path("/serde/"))
+        .and(matchers::query_param("search", "serde::Serialize"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(mock_html))
+        .mount(&mock_server)
+        .await;
+
+    let memory_cache = crates_docs::cache::memory::MemoryCache::new(100);
+    let cache = Arc::new(memory_cache);
+    let cache_config = crates_docs::cache::CacheConfig::default();
+    let request_count = Arc::new(AtomicUsize::new(0));
+
+    let service = crates_docs::tools::docs::DocService::with_custom_client(
+        cache,
+        &cache_config,
+        build_docs_rs_test_client(&mock_uri, request_count.clone()),
+    );
+
+    let tool = crates_docs::tools::docs::lookup_item::LookupItemToolImpl::new(Arc::new(service));
+
+    let markdown_args = serde_json::json!({
+        "crate_name": "serde",
+        "item_path": "serde::Serialize",
+        "format": "markdown"
+    });
+    let html_args = serde_json::json!({
+        "crate_name": "serde",
+        "item_path": "serde::Serialize",
+        "format": "html"
+    });
+
+    let markdown_result = tool.execute(markdown_args).await;
+    assert!(markdown_result.is_ok());
+
+    let html_result = tool.execute(html_args).await;
+    assert!(html_result.is_ok());
+
+    assert_eq!(
+        request_count.load(Ordering::SeqCst),
+        1,
+        "expected a single upstream request"
+    );
+}
+
+#[tokio::test]
+#[serial(docs_rs_env)]
+async fn test_lookup_item_tool_keeps_versioned_and_unversioned_cache_entries_distinct() {
+    use crates_docs::tools::Tool;
+    use wiremock::{matchers, Mock, MockServer, ResponseTemplate};
+
+    let mock_server = MockServer::start().await;
+    let mock_uri = mock_server.uri();
+
+    Mock::given(matchers::method("GET"))
+        .and(matchers::path("/serde/"))
+        .and(matchers::query_param("search", "serde::Serialize"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(r#"<html><body><h1>Serialize latest</h1></body></html>"#),
+        )
+        .mount(&mock_server)
+        .await;
+
+    Mock::given(matchers::method("GET"))
+        .and(matchers::path("/serde/1.0.0/"))
+        .and(matchers::query_param("search", "serde::Serialize"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(r#"<html><body><h1>Serialize 1.0.0</h1></body></html>"#),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let memory_cache = crates_docs::cache::memory::MemoryCache::new(100);
+    let cache = Arc::new(memory_cache);
+    let cache_config = crates_docs::cache::CacheConfig::default();
+    let request_count = Arc::new(AtomicUsize::new(0));
+
+    let service = crates_docs::tools::docs::DocService::with_custom_client(
+        cache,
+        &cache_config,
+        build_docs_rs_test_client(&mock_uri, request_count.clone()),
+    );
+
+    let tool = crates_docs::tools::docs::lookup_item::LookupItemToolImpl::new(Arc::new(service));
+
+    let latest_args = serde_json::json!({
+        "crate_name": "serde",
+        "item_path": "serde::Serialize",
+        "format": "markdown"
+    });
+    let versioned_args = serde_json::json!({
+        "crate_name": "serde",
+        "item_path": "serde::Serialize",
+        "version": "1.0.0",
+        "format": "text"
+    });
+
+    let latest_result = tool.execute(latest_args).await;
+    assert!(latest_result.is_ok());
+
+    let versioned_result = tool.execute(versioned_args).await;
+    assert!(versioned_result.is_ok());
+
+    assert_eq!(
+        request_count.load(Ordering::SeqCst),
+        2,
+        "expected separate upstream requests"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add a raw HTML cache tier for docs lookups so `lookup_crate` and `lookup_item` reuse a single upstream fetch across markdown, text, and html outputs
- keep versioned and unversioned lookup cache entries distinct to avoid cross-version reuse
- add regression tests that prove cross-format lookups only trigger one upstream request while preserving existing output behavior

## Verification
- cargo fmt -- --check
- cargo clippy --all-targets -- -D warnings
- cargo clippy --all-features --all-targets -- -D warnings
- cargo test --test unit tools_docs_tests