### PR TITLE
fix: add #[serial(crates_io_env)] to fix flaky test

### DIFF
--- a/tests/unit/tools_docs_tests.rs
+++ b/tests/unit/tools_docs_tests.rs
@@ -1173,6 +1173,7 @@ async fn test_search_crates_tool_execute_json_format() {
 }
 
 #[tokio::test]
+#[serial(crates_io_env)]
 async fn test_search_crates_tool_invalid_sort() {
     use crates_docs::tools::Tool;
 


### PR DESCRIPTION
## Problem

The test `test_search_crates_tool_invalid_sort` was missing the `#[serial(crates_io_env)]` attribute, causing race conditions with other tests that set the `CRATES_DOCS_CRATES_IO_URL` environment variable.

When tests run in parallel, this test could read stale environment variable values from other tests, leading to flaky behavior.

## Solution

Added `#[serial(crates_io_env)]` to ensure this test runs serially with respect to other tests that access the same environment variable.

## Changes

- Added `#[serial(crates_io_env)]` attribute to `test_search_crates_tool_invalid_sort` in `tests/unit/tools_docs_tests.rs`

## Testing

- ✅ Local test passed: `cargo test --test unit test_search_crates_tool_invalid_sort`
- ✅ Build passed: `cargo build`
- ✅ Based on latest main: `7bdfa1d` (includes PR #56 optimizations)

## Related

This is a clean replacement for the closed PR #52, which had merge conflicts with the updated main branch.