### PR TITLE
fix: use vars context instead of env in job if condition

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -6,14 +6,11 @@ on:
   pull_request_review_comment:
     types: [created]
 
-env:
-  ALLOWED_USERS: ${{ vars.ALLOWED_USERS || '["KingingWang"]' }}
-
 jobs:
   opencode:
     if: |
       (contains(github.event.comment.body, '/oc') || contains(github.event.comment.body, '/opencode')) &&
-      contains(fromJSON(env.ALLOWED_USERS), github.event.comment.user.login)
+      contains(fromJSON(vars.ALLOWED_USERS || '["KingingWang"]'), github.event.comment.user.login)
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

Fixes a workflow syntax error where `env` context was incorrectly used in a job-level `if` condition.

## Problem

The `env` context is **not available at job level** in GitHub Actions. Only these contexts can be used in job conditions:
- `github`
- `vars` (repository variables)
- `inputs`
- `matrix`

## Error Fixed

```
(Line: 14, Col: 9): Unrecognized named-value: 'env'. Located at position 119 within expression
```

## Changes

- Removed the `env:` block at workflow level
- Changed from: `contains(fromJSON(env.ALLOWED_USERS), github.event.comment.user.login)`
- Changed to: `contains(fromJSON(vars.ALLOWED_USERS || '["KingingWang"]'), github.event.comment.user.login)`

## Configuration

Users can now set a repository variable `ALLOWED_USERS` in Settings > Secrets and variables > Actions > Variables with format:
```json
["KingingWang", "otherUser"]
```

Default value (if not set): `["KingingWang"]`

## Test Plan

Workflow should now parse correctly when triggered.