### PR TITLE
fix(opencode): prevent workflow feedback loop from self-triggering

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   opencode:
     if: |
-      (contains(github.event.comment.body, '/oc') || contains(github.event.comment.body, '/opencode')) &&
+      (startsWith(github.event.comment.body, '/oc') || startsWith(github.event.comment.body, '/opencode') || startsWith(github.event.comment.body, '@oc') || startsWith(github.event.comment.body, '@opencode')) &&
       contains(fromJSON(vars.ALLOWED_USERS || '["KingingWang"]'), github.event.comment.user.login)
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Problem

The OpenCode workflow was triggering repeatedly in an infinite feedback loop after PR merges. Each OpenCode response comment triggered another workflow run, causing dozens of unnecessary workflow runs within minutes.

## Root Cause

The workflow condition used `contains(github.event.comment.body, '/opencode')` which matched the word "opencode" anywhere in the comment body. This caused:

1. User comments `/oc review this PR`
2. Workflow triggers → OpenCode responds
3. Response contains `[opencode session](https://opencode.ai/s/...)` link
4. Workflow sees "opencode" in link → triggers again
5. **Infinite loop** 🔄

**Evidence**: 10+ workflow runs within 3 minutes, all from `issue_comment` events on the same PR.

## Solution

Changed condition from `contains()` to `startsWith()` to only match commands that begin at the start of the comment:

```yaml
# Before (causes feedback loop)
contains(github.event.comment.body, '/opencode')

# After (prevents feedback loop)
startsWith(github.event.comment.body, '/opencode')
```

Added support for both `/oc` and `@oc` command formats.

## Testing

Test scenarios verified:
- ✅ Response comments: `startsWith('[opencode session]', '/oc')` = FALSE (won't trigger)
- ✅ User commands: `startsWith('/oc review', '/oc')` = TRUE (triggers correctly)
- ✅ Alternative formats: `startsWith('@opencode help', '@opencode')` = TRUE (triggers correctly)
- ✅ Mid-comment commands: `startsWith('Thanks! /oc', '/oc')` = FALSE (safe)

## Usage

After merging, trigger OpenCode with:
- `/oc <message>` at the start of any Issue/PR comment
- `/opencode <message>` at the start of any Issue/PR comment
- `@oc <message>` or `@opencode <message>` also work

Commands **must** be at the beginning of the comment to trigger the workflow.