### PR TITLE
perf: use Arc<str> instead of Arc<String> for cache storage

### DIFF
--- a/src/cache/memory.rs
+++ b/src/cache/memory.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 /// Cache entry with optional TTL
 #[derive(Clone, Debug)]
 struct CacheEntry {
-    value: Arc<String>,
+    value: Arc<str>,
     ttl: Option<Duration>,
 }
 
@@ -79,7 +79,7 @@ impl MemoryCache {
 #[async_trait::async_trait]
 impl super::Cache for MemoryCache {
     #[tracing::instrument(skip(self), level = "trace")]
-    async fn get(&self, key: &str) -> Option<Arc<String>> {
+    async fn get(&self, key: &str) -> Option<Arc<str>> {
         let result = self.cache.get(key).map(|entry| Arc::clone(&entry.value));
         if result.is_some() {
             tracing::trace!(cache_type = "memory", key = %key, "Cache hit");
@@ -97,7 +97,7 @@ impl super::Cache for MemoryCache {
         ttl: Option<Duration>,
     ) -> crate::error::Result<()> {
         let entry = CacheEntry {
-            value: Arc::new(value),
+            value: Arc::from(value.into_boxed_str()),
             ttl,
         };
         tracing::trace!(cache_type = "memory", key = %key, "Setting cache entry");

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -91,8 +91,8 @@ pub trait Cache: Send + Sync {
     ///
     /// # Returns
     ///
-    /// If key exists and not expired, returns `Arc<String>` to avoid cloning; otherwise returns `None`
-    async fn get(&self, key: &str) -> Option<Arc<String>>;
+    /// If key exists and not expired, returns `Arc<str>` to avoid cloning; otherwise returns `None`
+    async fn get(&self, key: &str) -> Option<Arc<str>>;
 
     /// Set cache value
     ///

--- a/src/cache/redis.rs
+++ b/src/cache/redis.rs
@@ -83,15 +83,14 @@ impl RedisCache {
 
 #[async_trait::async_trait]
 impl super::Cache for RedisCache {
-    async fn get(&self, key: &str) -> Option<Arc<String>> {
+    async fn get(&self, key: &str) -> Option<Arc<str>> {
         let mut conn = self.conn.clone();
         let full_key = self.build_key(key);
-        redis::cmd("GET")
+        let result: redis::RedisResult<Option<String>> = redis::cmd("GET")
             .arg(&full_key)
             .query_async(&mut conn)
-            .await
-            .ok()
-            .map(Arc::new)
+            .await;
+        result.ok().flatten().map(|s| Arc::from(s.into_boxed_str()))
     }
 
     #[allow(clippy::cast_possible_truncation)]

--- a/src/tools/docs/cache/mod.rs
+++ b/src/tools/docs/cache/mod.rs
@@ -119,7 +119,7 @@ impl DocCache {
         &self,
         crate_name: &str,
         version: Option<&str>,
-    ) -> Option<Arc<String>> {
+    ) -> Option<Arc<str>> {
         let key = CacheKeyGenerator::crate_cache_key(crate_name, version);
         let result = self.cache.get(&key).await;
         let is_hit = result.is_some();
@@ -179,14 +179,14 @@ impl DocCache {
 
     /// Get cached crate HTML
     ///
-    /// Returns `Arc<String>` to avoid unnecessary cloning on cache hits.
+    /// Returns `Arc<str>` to avoid unnecessary cloning on cache hits.
     /// The caller can clone if an owned String is needed.
     #[tracing::instrument(skip(self), fields(crate = crate_name, version = version), level = "trace")]
     pub async fn get_crate_html(
         &self,
         crate_name: &str,
         version: Option<&str>,
-    ) -> Option<Arc<String>> {
+    ) -> Option<Arc<str>> {
         let key = CacheKeyGenerator::crate_html_cache_key(crate_name, version);
         let result = self.cache.get(&key).await;
         let is_hit = result.is_some();
@@ -255,7 +255,7 @@ impl DocCache {
         query: &str,
         limit: u32,
         sort: Option<&str>,
-    ) -> Option<Arc<String>> {
+    ) -> Option<Arc<str>> {
         let key = CacheKeyGenerator::search_cache_key(query, limit, sort);
         let result = self.cache.get(&key).await;
         let is_hit = result.is_some();
@@ -330,7 +330,7 @@ impl DocCache {
         crate_name: &str,
         item_path: &str,
         version: Option<&str>,
-    ) -> Option<Arc<String>> {
+    ) -> Option<Arc<str>> {
         let key = CacheKeyGenerator::item_cache_key(crate_name, item_path, version);
         let result = self.cache.get(&key).await;
         let is_hit = result.is_some();
@@ -382,7 +382,7 @@ impl DocCache {
 
     /// Get cached item HTML
     ///
-    /// Returns `Arc<String>` to avoid unnecessary cloning on cache hits.
+    /// Returns `Arc<str>` to avoid unnecessary cloning on cache hits.
     /// The caller can clone if an owned String is needed.
     #[tracing::instrument(skip(self), fields(crate = crate_name, item = item_path, version), level = "trace")]
     pub async fn get_item_html(
@@ -390,7 +390,7 @@ impl DocCache {
         crate_name: &str,
         item_path: &str,
         version: Option<&str>,
-    ) -> Option<Arc<String>> {
+    ) -> Option<Arc<str>> {
         let key = CacheKeyGenerator::item_html_cache_key(crate_name, item_path, version);
         let result = self.cache.get(&key).await;
         let is_hit = result.is_some();
@@ -489,7 +489,10 @@ mod tests {
             .await
             .expect("set_crate_docs should succeed");
         let cached = doc_cache.get_crate_docs("serde", Some("1.0")).await;
-        assert_eq!(cached.as_deref().map(String::as_str), Some("Test docs"));
+        assert_eq!(
+            cached.as_ref().map(std::convert::AsRef::as_ref),
+            Some("Test docs")
+        );
 
         // Test search results cache
         doc_cache
@@ -505,7 +508,7 @@ mod tests {
             .get_search_results("web framework", 10, Some("relevance"))
             .await;
         assert_eq!(
-            search_cached.as_deref().map(String::as_str),
+            search_cached.as_ref().map(std::convert::AsRef::as_ref),
             Some("Search results")
         );
 
@@ -523,7 +526,7 @@ mod tests {
             .get_item_docs("serde", "serde::Serialize", Some("1.0"))
             .await;
         assert_eq!(
-            item_cached.as_deref().map(String::as_str),
+            item_cached.as_ref().map(std::convert::AsRef::as_ref),
             Some("Item docs")
         );
 

--- a/src/tools/docs/lookup_crate.rs
+++ b/src/tools/docs/lookup_crate.rs
@@ -98,7 +98,7 @@ impl LookupCrateToolImpl {
             .get_crate_html(crate_name, version)
             .await
         {
-            return Ok(cached.as_ref().clone());
+            return Ok(cached.to_string());
         }
 
         let url = Self::build_url(crate_name, version);
@@ -117,14 +117,14 @@ impl LookupCrateToolImpl {
 
     /// Get crate documentation (markdown format)
     ///
-    /// Returns `Arc<String>` to preserve shared ownership on cache hits,
+    /// Returns `Arc<str>` to preserve shared ownership on cache hits,
     /// avoiding unnecessary cloning of large documentation strings.
     async fn fetch_crate_docs(
         &self,
         crate_name: &str,
         version: Option<&str>,
-    ) -> std::result::Result<Arc<String>, CallToolError> {
-        // Try cache first - returns Arc<String> directly without cloning
+    ) -> std::result::Result<Arc<str>, CallToolError> {
+        // Try cache first - returns Arc<str> directly without cloning
         if let Some(cached) = self
             .service
             .doc_cache()
@@ -136,14 +136,13 @@ impl LookupCrateToolImpl {
 
         let html = self.fetch_crate_html(crate_name, version).await?;
 
-        // Extract documentation into Arc<String> for shared ownership
-        let docs: Arc<String> = Arc::new(html::extract_documentation(&html));
+        // Extract documentation into Arc<str> for shared ownership
+        let docs: Arc<str> = Arc::from(html::extract_documentation(&html).into_boxed_str());
 
-        // Cache result - clone the Arc's inner String for the cache
-        // This is necessary because the cache interface takes ownership of String
+        // Cache result - convert Arc<str> to String for the cache
         self.service
             .doc_cache()
-            .set_crate_docs(crate_name, version, (*docs).clone())
+            .set_crate_docs(crate_name, version, docs.to_string())
             .await
             .map_err(|e| {
                 CallToolError::from_message(format!("[{TOOL_NAME}] Cache set failed: {e}"))
@@ -216,7 +215,7 @@ impl Tool for LookupCrateToolImpl {
             super::Format::Markdown => self
                 .fetch_crate_docs(&params.crate_name, params.version.as_deref())
                 .await
-                .map(|arc| (*arc).clone())?,
+                .map(|arc| arc.to_string())?,
         };
 
         Ok(rust_mcp_sdk::schema::CallToolResult::text_content(vec![

--- a/src/tools/docs/lookup_item.rs
+++ b/src/tools/docs/lookup_item.rs
@@ -102,7 +102,7 @@ impl LookupItemToolImpl {
             .get_item_html(crate_name, item_path, version)
             .await
         {
-            return Ok(cached.as_ref().clone());
+            return Ok(cached.to_string());
         }
 
         let url = Self::build_search_url(crate_name, item_path, version);
@@ -121,15 +121,15 @@ impl LookupItemToolImpl {
 
     /// Get item documentation (markdown format)
     ///
-    /// Returns `Arc<String>` to preserve shared ownership on cache hits,
+    /// Returns `Arc<str>` to preserve shared ownership on cache hits,
     /// avoiding unnecessary cloning of large documentation strings.
     async fn fetch_item_docs(
         &self,
         crate_name: &str,
         item_path: &str,
         version: Option<&str>,
-    ) -> std::result::Result<Arc<String>, CallToolError> {
-        // Try cache first - returns Arc<String> directly without cloning
+    ) -> std::result::Result<Arc<str>, CallToolError> {
+        // Try cache first - returns Arc<str> directly without cloning
         if let Some(cached) = self
             .service
             .doc_cache()
@@ -141,13 +141,14 @@ impl LookupItemToolImpl {
 
         let html = self.fetch_item_html(crate_name, item_path, version).await?;
 
-        // Extract search results into Arc<String> for shared ownership
-        let docs: Arc<String> = Arc::new(html::extract_search_results(&html, item_path));
+        // Extract search results into Arc<str> for shared ownership
+        let docs: Arc<str> =
+            Arc::from(html::extract_search_results(&html, item_path).into_boxed_str());
 
-        // Cache result - clone the Arc's inner String for the cache
+        // Cache result - convert Arc<str> to String for the cache
         self.service
             .doc_cache()
-            .set_item_docs(crate_name, item_path, version, (*docs).clone())
+            .set_item_docs(crate_name, item_path, version, docs.to_string())
             .await
             .map_err(|e| {
                 CallToolError::from_message(format!("[{TOOL_NAME}] Cache set failed: {e}"))
@@ -238,7 +239,7 @@ impl Tool for LookupItemToolImpl {
                     params.version.as_deref(),
                 )
                 .await
-                .map(|arc| (*arc).clone())?,
+                .map(|arc| arc.to_string())?,
         };
 
         Ok(rust_mcp_sdk::schema::CallToolResult::text_content(vec![

--- a/tests/e2e/external_api_tests.rs
+++ b/tests/e2e/external_api_tests.rs
@@ -206,7 +206,7 @@ async fn test_cache_key_formats() {
         let value = cache.get(key).await;
         assert!(value.is_some(), "Cache key {} failed", key);
         assert_eq!(
-            value.unwrap().as_str(),
+            value.unwrap().as_ref(),
             expected_value.as_str(),
             "Cache key {} value mismatch",
             key
@@ -278,7 +278,7 @@ async fn test_concurrent_cache_access() {
                 i
             );
             assert_eq!(
-                retrieved.unwrap().as_str(),
+                retrieved.unwrap().as_ref(),
                 value.as_str(),
                 "Concurrent access value mismatch for key {}",
                 i

--- a/tests/unit/cache_tests.rs
+++ b/tests/unit/cache_tests.rs
@@ -129,7 +129,7 @@ async fn test_doc_cache_crate_docs() {
     // Test cache hit
     let result = doc_cache.get_crate_docs("serde", None).await;
     assert_eq!(
-        result.as_deref().map(String::as_str),
+        result.as_ref().map(|s| s.as_ref()),
         Some("Serde documentation")
     );
 
@@ -139,10 +139,7 @@ async fn test_doc_cache_crate_docs() {
         .await
         .expect("set_crate_docs should succeed");
     let result = doc_cache.get_crate_docs("tokio", Some("1.0.0")).await;
-    assert_eq!(
-        result.as_deref().map(String::as_str),
-        Some("Tokio 1.0 docs")
-    );
+    assert_eq!(result.as_ref().map(|s| s.as_ref()), Some("Tokio 1.0 docs"));
 
     // Different versions should return different cached values
     let result = doc_cache.get_crate_docs("tokio", Some("1.1.0")).await;
@@ -178,7 +175,7 @@ async fn test_doc_cache_item_docs() {
         .get_item_docs("serde", "serde::Serialize", None)
         .await;
     assert_eq!(
-        result.as_deref().map(String::as_str),
+        result.as_ref().map(|s| s.as_ref()),
         Some("Serialize trait docs")
     );
 
@@ -195,7 +192,7 @@ async fn test_doc_cache_item_docs() {
     let result = doc_cache
         .get_item_docs("std", "std::collections::HashMap", Some("1.75.0"))
         .await;
-    assert_eq!(result.as_deref().map(String::as_str), Some("HashMap docs"));
+    assert_eq!(result.as_ref().map(|s| s.as_ref()), Some("HashMap docs"));
 }
 
 // ============================================================================

--- a/tests/unit/tools_docs_tests.rs
+++ b/tests/unit/tools_docs_tests.rs
@@ -132,7 +132,7 @@ async fn test_doc_cache_crate_docs() {
 
     let result = doc_cache.get_crate_docs("serde", Some("1.0.0")).await;
     assert_eq!(
-        result.as_deref().map(String::as_str),
+        result.as_ref().map(|s| s.as_ref()),
         Some("Serde documentation")
     );
 
@@ -162,10 +162,7 @@ async fn test_doc_cache_search_results() {
     let result = doc_cache
         .get_search_results("web framework", 10, Some("relevance"))
         .await;
-    assert_eq!(
-        result.as_deref().map(String::as_str),
-        Some("Search results")
-    );
+    assert_eq!(result.as_ref().map(|s| s.as_ref()), Some("Search results"));
 
     // Test different limit
     let result = doc_cache
@@ -196,7 +193,7 @@ async fn test_doc_cache_item_docs() {
         .get_item_docs("serde", "serde::Serialize", Some("1.0.0"))
         .await;
     assert_eq!(
-        result.as_deref().map(String::as_str),
+        result.as_ref().map(|s| s.as_ref()),
         Some("Serialize trait docs")
     );
 }
@@ -1661,7 +1658,7 @@ async fn test_doc_cache_version_normalization() {
 
     // Should be accessible with normalized version
     let result = doc_cache.get_crate_docs("serde", Some("1.0.0")).await;
-    assert_eq!(result.as_deref().map(String::as_str), Some("docs"));
+    assert_eq!(result.as_ref().map(|s| s.as_ref()), Some("docs"));
 }
 
 #[tokio::test]
@@ -1677,7 +1674,7 @@ async fn test_doc_cache_case_insensitive_crate_name() {
 
     // Should be accessible with lowercase
     let result = doc_cache.get_crate_docs("serde", None).await;
-    assert_eq!(result.as_deref().map(String::as_str), Some("docs"));
+    assert_eq!(result.as_ref().map(|s| s.as_ref()), Some("docs"));
 }
 
 // ============================================================================
@@ -1703,7 +1700,7 @@ async fn test_doc_cache_concurrent_access() {
 
             let result = doc_cache_clone.get_crate_docs(&key, None).await;
             assert_eq!(
-                result.as_deref().map(String::as_str),
+                result.as_ref().map(|s| s.as_ref()),
                 Some(format!("docs_{}", i).as_str())
             );
         });

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -79,7 +79,7 @@ async fn test_doc_cache_crate_docs() {
     // Test cache hit
     let result = doc_cache.get_crate_docs("serde", None).await;
     assert_eq!(
-        result.as_deref().map(String::as_str),
+        result.as_ref().map(|s| s.as_ref()),
         Some("Serde documentation")
     );
 
@@ -89,10 +89,7 @@ async fn test_doc_cache_crate_docs() {
         .await
         .expect("set_crate_docs should succeed");
     let result = doc_cache.get_crate_docs("tokio", Some("1.0.0")).await;
-    assert_eq!(
-        result.as_deref().map(String::as_str),
-        Some("Tokio 1.0 docs")
-    );
+    assert_eq!(result.as_ref().map(|s| s.as_ref()), Some("Tokio 1.0 docs"));
 
     // Different versions should return different cached values
     let result = doc_cache.get_crate_docs("tokio", Some("1.1.0")).await;
@@ -129,7 +126,7 @@ async fn test_doc_cache_item_docs() {
         .get_item_docs("serde", "serde::Serialize", None)
         .await;
     assert_eq!(
-        result.as_deref().map(String::as_str),
+        result.as_ref().map(|s| s.as_ref()),
         Some("Serialize trait docs")
     );
 
@@ -146,7 +143,7 @@ async fn test_doc_cache_item_docs() {
     let result = doc_cache
         .get_item_docs("std", "std::collections::HashMap", Some("1.75.0"))
         .await;
-    assert_eq!(result.as_deref().map(String::as_str), Some("HashMap docs"));
+    assert_eq!(result.as_ref().map(|s| s.as_ref()), Some("HashMap docs"));
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Optimize memory usage by using `Arc<str>` instead of `Arc<String>` for cached values.

## Changes

- **Cache trait**: Changed `get()` return type from `Option<Arc<String>>` to `Option<Arc<str>>`
- **MemoryCache**: `CacheEntry` now stores `Arc<str>` instead of `Arc<String>`
- **RedisCache**: `get()` returns `Option<Arc<str>>` with proper type conversion
- **DocCache**: All getter methods return `Option<Arc<str>>`
- **lookup_crate/lookup_item**: Fetch methods return `Arc<str>` for better memory efficiency
- **Tests**: Updated all test assertions to work with `Arc<str>`

## Benefits

- Lower memory overhead: `Arc<str>` doesn't store capacity field like `String`
- More appropriate for immutable cached data
- Reduces memory footprint per cache entry

## Testing

- All 291 unit tests pass
- All clippy checks pass with `-D warnings`
- All features compile successfully

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)