### PR TITLE
refactor(html): remove unused regex patterns for cleaner code

### DIFF
--- a/src/tools/docs/html.rs
+++ b/src/tools/docs/html.rs
@@ -11,28 +11,7 @@ use std::sync::LazyLock;
 /// Tags whose content should be completely removed during HTML cleaning
 const SKIP_TAGS: &[&str] = &["script", "style", "noscript", "iframe"];
 
-/// Regex patterns for self-closing/void tags to remove
-#[expect(
-    dead_code,
-    reason = "Kept for API consistency; COMBINED_CLEANUP_REGEX is now used"
-)]
-static LINK_TAG_REGEX: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"<link[^>]*>").expect("hardcoded valid regex pattern"));
-
-#[expect(
-    dead_code,
-    reason = "Kept for API consistency; COMBINED_CLEANUP_REGEX is now used"
-)]
-static META_TAG_REGEX: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"<meta[^>]*>").expect("hardcoded valid regex pattern"));
-
-/// Regex to remove "Copy item path" and similar UI text
-#[expect(
-    dead_code,
-    reason = "Pattern is included in COMBINED_CLEANUP_REGEX for single-pass optimization"
-)]
-static COPY_PATH_REGEX: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"Copy item path").expect("hardcoded valid regex pattern"));
+// Regex patterns for HTML cleanup (combined into COMBINED_CLEANUP_REGEX for efficiency)
 
 /// Regex to remove anchor links like [§](#xxx)
 static ANCHOR_LINK_REGEX: LazyLock<Regex> =


### PR DESCRIPTION
## Summary
- Remove unused static regex patterns (LINK_TAG_REGEX, META_TAG_REGEX, COPY_PATH_REGEX) from html.rs
- These patterns were marked with `#[expect(dead_code)]` but served no functional purpose
- The functionality is already handled by COMBINED_CLEANUP_REGEX for single-pass optimization

## Changes
- Deleted 22 lines of unused regex pattern definitions
- Replaced with a single comment explaining the optimization approach
- No functional changes - all tests pass

## Test plan
- [x] All 153 unit tests pass
- [x] Clippy reports no warnings
- [x] Code format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)